### PR TITLE
Fix infinite loop in ANTLRInputStream

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime/ANTLRInputStream.cs
+++ b/runtime/CSharp/Antlr4.Runtime/ANTLRInputStream.cs
@@ -138,7 +138,7 @@ namespace Antlr4.Runtime
             try
             {
                 // alloc initial buffer size.
-                data = new char[size];
+                data = new char[Math.Max(size,readChunkSize)];
                 // read all the data in chunks of readChunkSize
                 int numRead = 0;
                 int p = 0;


### PR DESCRIPTION
Checking for Stream.Read != -1 in ANTLRInputStream was causing an infinite loop.
Changing this to check for >0 fixed the problem.

See: http://msdn.microsoft.com/en-us/library/system.io.stream.read.aspx
Specifically " Read returns 0 only when there is no more data in the stream and no more is expected (such as a closed socket or end of file). "
