### PR TITLE
Small patches for minor compile issues in CSharp.stg

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -719,7 +719,7 @@ LexerMoreCommand()  ::= "More();"
 LexerPopModeCommand() ::= "PopMode();"
 
 LexerTypeCommand(arg)      ::= "_type = <arg>;"
-LexerChannelCommand(arg)   ::= "_channel = <arg>;"
+LexerChannelCommand(arg)   ::= "_channel = <arg>_CHANNEL;"
 LexerModeCommand(arg)      ::= "_mode = <arg>;"
 LexerPushModeCommand(arg)  ::= "PushMode(<arg>);"
 


### PR DESCRIPTION
Here's what's included:
1. Patch that marks all generated classes as not CLS compliant
2. Disable Xml documentation warnings for generated files (since the user would never be able to fix anyway)
3. Create local named constants in the lexer for the default channels (otherwise any channel references fail to compile).  This patch is kind of hackish
4. Make sure channels are referenced as `channelname_CHANNEL` (e.g. `HIDDEN_CHANNEL`).  This patch is kind of hackish.
