### PR TITLE
Small patches for minor compile issues in CSharp.stg

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -216,6 +216,14 @@ fileHeader(grammarFileName, ANTLRVersion) ::= <<
 //------------------------------------------------------------------------------
 
 // Generated from <grammarFileName> by ANTLR <ANTLRVersion>
+
+// Unreachable code detected
+#pragma warning disable 0162
+// The variable '...' is assigned but its value is never used
+#pragma warning disable 0219
+// Missing XML comment for publicly visible type or member '...'
+#pragma warning disable 1591
+
 >>
 
 Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<


### PR DESCRIPTION
Adjusted form of pull request #21:
1. Mark generated classes as 'non-CLS compliant'
2. Disable several compiler warnings don't make sense in generated code.  (NOTE:  I did not disable CS3019 since all the types are marked as 'public' in the current release - so this warning would never trigger).
