### PR TITLE
rename Eof -> EOF to match token name

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime/Recognizer`2.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Recognizer`2.cs
@@ -39,7 +39,7 @@ namespace Antlr4.Runtime
     public abstract class Recognizer<Symbol, ATNInterpreter> : IRecognizer
         where ATNInterpreter : ATNSimulator
     {
-        public const int Eof = -1;
+        public const int EOF = -1;
 
         [NotNull]
         private IAntlrErrorListener<Symbol>[] _listeners =


### PR DESCRIPTION
I'm unable to compile parsers that use EOF token because constant name is diffetent than ANTLR token name
