### PR TITLE
Add support for non-installed java distros

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -155,7 +155,11 @@ namespace Antlr4.Build.Tasks
         {
             get
             {
-                string javaHome;
+                // short-circuit for java environments that are copied and not installed
+                string javaHome = new Uri(JavaInstallation).LocalPath;
+                if (Directory.Exists(javaHome))
+                    return javaHome;
+
                 if (TryGetJavaHome(RegistryView.Default, JavaVendor, JavaInstallation, out javaHome))
                     return javaHome;
 
@@ -201,7 +205,11 @@ namespace Antlr4.Build.Tasks
         {
             get
             {
-                string javaHome;
+                // short-circuit for java environments that are copied and not installed
+                string javaHome = new Uri(JavaInstallation).LocalPath;
+                if (Directory.Exists(javaHome))
+                    return javaHome;
+
                 if (TryGetJavaHome(Registry.LocalMachine, JavaVendor, JavaInstallation, out javaHome))
                     return javaHome;
 


### PR DESCRIPTION
Allow JavaInstallation to reference the root of a java installation. If the value points at a valid directory, then try that as JavaHome. Our build environments do not have a standard java installation, instead we have a local copy in our build tree. Our custom .targets specifies Antlr4JavaInstallation as a full path to the installation. This change attempts to use that as a path, and if it is a valid path, it'll get returned
