### PR TITLE
Fix code generation support for .NET 4.5.1

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -271,6 +271,8 @@ namespace Antlr4.Build.Tasks
                     string framework = TargetFrameworkVersion;
                     if (string.IsNullOrEmpty(framework))
                         framework = "v2.0";
+                    if (framework == "v4.5.1")
+                        framework = "v4.5";
 
                     string language;
                     if (TargetLanguage.Equals("CSharp"))


### PR DESCRIPTION
This change causes the build tool to generate code for .NET 4.5 when the target framework is 4.5.1.
