### PR TITLE
Mark the parser generator NuGet packages as development dependencies.

### DIFF
--- a/build/Antlr4.VS2008.nuspec
+++ b/build/Antlr4.VS2008.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata minClientVersion="2.5">
+  <metadata minClientVersion="2.7">
     <id>Antlr4.VS2008</id>
     <version>0.0.0</version>
     <authors>Sam Harwell, Terence Parr</authors>

--- a/build/Antlr4.nuspec
+++ b/build/Antlr4.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata minClientVersion="2.5">
+  <metadata minClientVersion="2.7">
     <id>Antlr4</id>
     <version>0.0.0</version>
     <authors>Sam Harwell, Terence Parr</authors>


### PR DESCRIPTION
This adjustment makes it so NuGet knows that the parser generator's only needed when developing.

See http://docs.nuget.org/docs/release-notes/nuget-2.7#Development-Only_Dependencies
