### PR TITLE
Use unique assembly names for test projects

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net20.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net20.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.net20</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net30.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net30.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.net30</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net35-client.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net35-client.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.net35_client</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net40-client.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net40-client.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.net40_client</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net45.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net45.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.net45</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net40.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net40.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.portable_net40</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net45.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net45.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Antlr4.Runtime.Test</RootNamespace>
-    <AssemblyName>Antlr4.Runtime.Test</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Test.portable_net45</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
This change allows Visual Studio to load all tests at once in the Test Explorer.
