### PR TITLE
Support launching ANTLR as a standalone executable

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -251,23 +251,31 @@ namespace Antlr4.Build.Tasks
         {
             try
             {
-                string java;
-                if (!string.IsNullOrEmpty(JavaExecutable))
+                string path;
+                List<string> arguments = new List<string>();
+
+                if (!string.IsNullOrEmpty(ToolPath) && !Path.GetExtension(ToolPath).Equals(".jar", StringComparison.OrdinalIgnoreCase))
                 {
-                    java = JavaExecutable;
+                    path = ToolPath;
                 }
                 else
                 {
-                    string javaHome = JavaHome;
-                    java = Path.Combine(Path.Combine(javaHome, "bin"), "java.exe");
-                    if (!File.Exists(java))
-                        java = Path.Combine(Path.Combine(javaHome, "bin"), "java");
-                }
+                    if (!string.IsNullOrEmpty(JavaExecutable))
+                    {
+                        path = JavaExecutable;
+                    }
+                    else
+                    {
+                        string javaHome = JavaHome;
+                        path = Path.Combine(Path.Combine(javaHome, "bin"), "java.exe");
+                        if (!File.Exists(path))
+                            path = Path.Combine(Path.Combine(javaHome, "bin"), "java");
+                    }
 
-                List<string> arguments = new List<string>();
-                arguments.Add("-cp");
-                arguments.Add(ToolPath);
-                arguments.Add("org.antlr.v4.CSharpTool");
+                    arguments.Add("-cp");
+                    arguments.Add(ToolPath);
+                    arguments.Add("org.antlr.v4.CSharpTool");
+                }
 
                 arguments.Add("-o");
                 arguments.Add(OutputPath);
@@ -313,7 +321,7 @@ namespace Antlr4.Build.Tasks
 
                 arguments.AddRange(SourceCodeFiles);
 
-                ProcessStartInfo startInfo = new ProcessStartInfo(java, JoinArguments(arguments))
+                ProcessStartInfo startInfo = new ProcessStartInfo(path, JoinArguments(arguments))
                 {
                     UseShellExecute = false,
                     CreateNoWindow = true,


### PR DESCRIPTION
The default behavior should be unchanged. If ToolPath does not point to a JAR, however, we now assume it is a standalone executable and do not attempt to run it with Java.

The use case that inspired this change is using an IKVM.NET static conversion of ANTLR to avoid the need to have Java installed on every machine that will build the project. Without this change it is already possible to override JavaExecutable to point to ikvm.exe and thus use IKVM.NET in dynamic mode, but this runs much more slowly and requires distributing the rather large IKVM.NET with the project.

If you wanted to try out that specific use case, grab the latest build of IKVM.NET and run `ikvmc -target:exe -main:org.antlr.v4.CSharpTool antlr4-csharp-4.3-complete.jar` then edit Antlr4ToolLocation to point to the .exe generated by that command. Only four IKVM libraries are required to run the generated executable: Core, Text, Util, and Runtime.