### PR TITLE
Use IKVM to remove the Java dependency from the tool

### DIFF
--- a/build/Antlr4.VS2008.nuspec
+++ b/build/Antlr4.VS2008.nuspec
@@ -25,6 +25,25 @@
     <!-- Tools -->
 
     <file src="..\tool\target\antlr4-csharp-$CSharpToolVersion$-complete.jar" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe.config" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Core.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Text.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Charsets.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Naming.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Management.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Beans.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Corba.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Util.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Security.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.JNI.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.SwingAWT.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Remoting.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.XML.API.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Misc.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Media.dll" target="tools"/>
 
     <!-- Build Configuration -->
 

--- a/build/Antlr4.nuspec
+++ b/build/Antlr4.nuspec
@@ -25,6 +25,25 @@
     <!-- Tools -->
 
     <file src="..\tool\target\antlr4-csharp-$CSharpToolVersion$-complete.jar" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe.config" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Core.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Text.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Charsets.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Naming.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Management.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Beans.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Corba.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Util.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Security.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.JNI.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.SwingAWT.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Remoting.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.XML.API.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Misc.dll" target="tools"/>
+    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Media.dll" target="tools"/>
 
     <!-- Build Configuration -->
 

--- a/runtime/CSharp/.nuget/packages.config
+++ b/runtime/CSharp/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="IKVM-WithExes" version="7.3.4830.1" targetFramework="net4" />
+</packages>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -252,16 +252,24 @@ namespace Antlr4.Build.Tasks
             try
             {
                 string java;
-                if (!string.IsNullOrEmpty(JavaExecutable))
+                try
                 {
-                    java = JavaExecutable;
+                    if (!string.IsNullOrEmpty(JavaExecutable))
+                    {
+                        java = JavaExecutable;
+                    }
+                    else
+                    {
+                        string javaHome = JavaHome;
+                        java = Path.Combine(Path.Combine(javaHome, "bin"), "java.exe");
+                        if (!File.Exists(java))
+                            java = Path.Combine(Path.Combine(javaHome, "bin"), "java");
+                    }
                 }
-                else
+                catch (NotSupportedException)
                 {
-                    string javaHome = JavaHome;
-                    java = Path.Combine(Path.Combine(javaHome, "bin"), "java.exe");
-                    if (!File.Exists(java))
-                        java = Path.Combine(Path.Combine(javaHome, "bin"), "java");
+                    // Fall back to using IKVM
+                    java = Path.Combine(Path.GetDirectoryName(ToolPath), "ikvm.exe");
                 }
 
                 List<string> arguments = new List<string>();


### PR DESCRIPTION
Fixes #94
Fixes #100
Fixes #102

:memo: This works (the output is binary identical to the output when Java was used), but the code generation is *substantially* slower than previously when it ran as a Java process. It results in pronounced delays when working in Visual Studio, particularly for the following operations which trigger IntelliSense updates:

* Opening a project containing grammars
* Changing editor tabs from a grammar file to another file, when one or more grammar files has been modified but not yet saved
