### PR TITLE
Resolve method references in doc comments.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -70,9 +70,9 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -80,9 +80,9 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -116,13 +116,23 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseListener : I<file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /// \<summary>
-/// Enter a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Enter a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+<else>
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}
 /// \<summary>
-/// Exit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Exit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+<else>
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -168,9 +178,9 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -204,7 +214,12 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeVisitor\<Result>, I<file.grammarName>Visitor\<Result> {
 	<file.visitorNames:{lname |
 /// \<summary>
-/// Visit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.visitorLabelRuleNames.(lname))>
+/// Visit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
+<else>
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+<endif>
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>
 /// on \<paramref name="context"/>.

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -70,9 +70,9 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -80,9 +80,9 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -116,23 +116,13 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseListener : I<file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /// \<summary>
-<if(file.listenerLabelRuleNames.(lname))>
-/// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
-<else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
-<endif>
+/// Enter a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}
 /// \<summary>
-<if(file.listenerLabelRuleNames.(lname))>
-/// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
-<else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
-<endif>
+/// Exit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -178,9 +168,9 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -214,12 +204,7 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeVisitor\<Result>, I<file.grammarName>Visitor\<Result> {
 	<file.visitorNames:{lname |
 /// \<summary>
-<if(file.visitorLabelRuleNames.(lname))>
-/// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
-<else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
-<endif>
+/// Visit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>
 /// on \<paramref name="context"/>.

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -116,13 +116,23 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseListener : I<file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /// \<summary>
-/// Enter a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Enter a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+<else>
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}
 /// \<summary>
-/// Exit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Exit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+<else>
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -204,7 +214,12 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeVisitor\<Result>, I<file.grammarName>Visitor\<Result> {
 	<file.visitorNames:{lname |
 /// \<summary>
-/// Visit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.visitorLabelRuleNames.(lname))>
+/// Visit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
+<else>
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>
 /// on \<paramref name="context"/>.
@@ -238,6 +253,8 @@ fileHeader(grammarFileName, ANTLRVersion) ::= <<
 #pragma warning disable 0219
 // Missing XML comment for publicly visible type or member '...'
 #pragma warning disable 1591
+// Ambiguous reference in cref attribute
+#pragma warning disable 419
 
 >>
 


### PR DESCRIPTION
This change resolves method references in the doc comments of the base listener and visitor classes and expands labeled rule comments to include the label name as it appears in the corresponding interface definition.