### PR TITLE
Fix error reporting from build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+os: Visual Studio 2015
+configuration: Debug
+init:
+- git config --global core.autocrlf true
+environment:
+  M2_HOME: C:\bin\apache-maven-3.3.1
+install:
+- powershell -Command .\build\appveyor-install.ps1
+cache:
+- NETCFSetupv35.msi -> build\appveyor-install.ps1
+- NETCFv35PowerToys.msi -> build\appveyor-install.ps1
+build_script:
+- cd build
+- powershell -Command .\build.ps1 -VisualStudioVersion "14.0" -Verbosity minimal -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" -Java6Home "${env:ProgramFiles}\Java\jdk1.7.0\jre"
+- cd ..
+test: off
+artifacts:
+- path: build\nuget\*.nupkg

--- a/build/appveyor-install.ps1
+++ b/build/appveyor-install.ps1
@@ -1,0 +1,11 @@
+If (-not (Test-Path 'NETCFSetupv35.msi')) {
+	Invoke-WebRequest https://download.microsoft.com/download/c/b/e/cbe1c611-7f2f-4bcf-921d-2df718591e1e/NETCFSetupv35.msi -OutFile NETCFSetupv35.msi
+}
+
+If (-not (Test-Path 'NETCFv35PowerToys.msi')) {
+	Invoke-WebRequest https://download.microsoft.com/download/f/a/c/fac1342d-044d-4d88-ae97-d278ef697064/NETCFv35PowerToys.msi -OutFile NETCFv35PowerToys.msi
+}
+
+msiexec.exe /i NETCFSetupv35.msi /qn | Out-Null
+msiexec.exe /i NETCFv35PowerToys.msi /qn | Out-Null
+cinst maven -version 3.3.1

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -61,7 +61,11 @@ $CSharpToolVersion = $CSharpToolVersionNodeInfo.Node.InnerText.trim()
 $nuget = '..\runtime\CSharp\.nuget\NuGet.exe'
 
 # build the main project
-$msbuild = "$env:windir\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe"
+if ($VisualStudioVersion -eq '4.0') {
+	$msbuild = "$env:windir\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe"
+} Else {
+	$msbuild = "${env:ProgramFiles(x86)}\MSBuild\$VisualStudioVersion\Bin\MSBuild.exe"
+}
 
 &$nuget 'restore' $SolutionPath
 &$msbuild '/nologo' '/m' '/nr:false' "/t:$Target" "/p:Configuration=$BuildConfig" "/p:VisualStudioVersion=$VisualStudioVersion" "/p:KeyConfiguration=$KeyConfiguration" $SolutionPath

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -65,9 +65,9 @@ $msbuild = "$env:windir\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe"
 
 &$nuget 'restore' $SolutionPath
 &$msbuild '/nologo' '/m' '/nr:false' "/t:$Target" "/p:Configuration=$BuildConfig" "/p:VisualStudioVersion=$VisualStudioVersion" "/p:KeyConfiguration=$KeyConfiguration" $SolutionPath
-if ($LASTEXITCODE -ne 0) {
+if (-not $?) {
 	$host.ui.WriteErrorLine('Build failed, aborting!')
-	exit $p.ExitCode
+	Exit $LASTEXITCODE
 }
 
 # build the compact framework project
@@ -75,9 +75,9 @@ $msbuild = "$env:windir\Microsoft.NET\Framework\v4.0.30319\msbuild.exe"
 
 &$nuget 'restore' $CF35SolutionPath
 &$msbuild '/nologo' '/m' '/nr:false' '/t:rebuild' "/p:Configuration=$BuildConfig" "/p:KeyConfiguration=$KeyConfiguration" $CF35SolutionPath
-if ($LASTEXITCODE -ne 0) {
+if (-not $?) {
 	$host.ui.WriteErrorLine('.NET 3.5 Compact Framework Build failed, aborting!')
-	exit $p.ExitCode
+	Exit $LASTEXITCODE
 }
 
 if (-not (Test-Path 'nuget')) {
@@ -104,10 +104,10 @@ If (-not $SkipMaven) {
 
 	$MavenGoal = 'package'
 	&$MavenPath '-DskipTests=true' '--errors' '-e' '-Dgpg.useagent=true' "-Djava6.home=$Java6Home" '-Psonatype-oss-release' $MavenGoal
-	if ($LASTEXITCODE -ne 0) {
+	if (-not $?) {
 		$host.ui.WriteErrorLine('Maven build of the C# Target custom Tool failed, aborting!')
 		cd $OriginalPath
-		exit $p.ExitCode
+		Exit $LASTEXITCODE
 	}
 
 	cd $OriginalPath
@@ -127,8 +127,8 @@ if (-not $SkipKeyCheck) {
 		$assembly = Resolve-FullPath -Path "..\runtime\CSharp\Antlr4.Runtime\bin\$($pair.Key)\$BuildConfig\Antlr4.Runtime.dll"
 		# Run the actual check in a separate process or the current process will keep the assembly file locked
 		powershell -Command ".\check-key.ps1 -Assembly '$assembly' -ExpectedKey '$($pair.Value)' -Build '$($pair.Key)'"
-		if ($LASTEXITCODE -ne 0) {
-			Exit $p.ExitCode
+		if (-not $?) {
+			Exit $LASTEXITCODE
 		}
 	}
 }
@@ -145,4 +145,7 @@ ForEach ($package in $packages) {
 	}
 
 	&$nuget 'pack' ".\$package.nuspec" '-OutputDirectory' 'nuget' '-Prop' "Configuration=$BuildConfig" '-Version' "$AntlrVersion" '-Prop' "M2_REPO=$M2_REPO" '-Prop' "CSharpToolVersion=$CSharpToolVersion" '-Symbols'
+	if (-not $?) {
+		Exit $LASTEXITCODE
+	}
 }

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -99,7 +99,11 @@ If (-not $SkipMaven) {
 	$OriginalPath = $PWD
 
 	cd '..\tool'
-	$MavenPath = "$MavenHome\bin\mvn.bat"
+	$MavenPath = "$MavenHome\bin\mvn.cmd"
+	If (-not (Test-Path $MavenPath)) {
+		$MavenPath = "$MavenHome\bin\mvn.bat"
+	}
+
 	If (-not (Test-Path $MavenPath)) {
 		$host.ui.WriteErrorLine("Couldn't locate Maven binary: $MavenPath")
 		cd $OriginalPath


### PR DESCRIPTION
* Install [.NET Compact Framework 3.5 Redistributable](https://www.microsoft.com/en-us/download/confirmation.aspx?id=65) before build
* Install [Power Toys for .NET Compact Framework 3.5](https://www.microsoft.com/en-us/download/confirmation.aspx?id=13442) before build
* Install [Maven 3.3.1](https://chocolatey.org/packages/maven/3.3.1) before build
* ~~Install [Java Runtime 6.0.30](https://chocolatey.org/packages/javaruntime/6.0.30) before build~~ Build against Java 7 instead of Java 6
* Fix error checking in the build script
* Use the AppVeyor logger for MSBuild so messages are properly reported
* Reduce the build verbosity so important messages stand out better

Fixes #121

:memo: After I get this working, I'm planning to add an **appveyor.yml** file to the repository so it everyone can see the necessary steps to set up a build environment. :smile: