### PR TITLE
Added initial .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Some of the changes in #120 appear to be caused by not including a **.gitattributes** file. I ran a **git reset** after making this change to confirm that all files in the repository already adhere to this set of attributes.