### PR TITLE
Adding feedback to appveyor build

### DIFF
--- a/build/appveyor-install.ps1
+++ b/build/appveyor-install.ps1
@@ -1,11 +1,18 @@
 If (-not (Test-Path 'NETCFSetupv35.msi')) {
+	Write-Host 'Downloading Compact Framework'
 	Invoke-WebRequest https://download.microsoft.com/download/c/b/e/cbe1c611-7f2f-4bcf-921d-2df718591e1e/NETCFSetupv35.msi -OutFile NETCFSetupv35.msi
 }
 
 If (-not (Test-Path 'NETCFv35PowerToys.msi')) {
+	Write-Host 'Downloading Compact Framework Power Toys'
 	Invoke-WebRequest https://download.microsoft.com/download/f/a/c/fac1342d-044d-4d88-ae97-d278ef697064/NETCFv35PowerToys.msi -OutFile NETCFv35PowerToys.msi
 }
 
+Write-Host 'Installing Compact Framework'
 msiexec.exe /i NETCFSetupv35.msi /qn | Out-Null
+
+Write-Host 'Installing Compact Framework Power Toys'
 msiexec.exe /i NETCFv35PowerToys.msi /qn | Out-Null
+
+Write-Host 'Installing Maven'
 cinst maven -version 3.3.1


### PR DESCRIPTION
I just noticed the appveyor build for https://ci.appveyor.com/project/sharwell/antlr4cs/build/1.0.61 has been running for over 12 minutes inside the appveyor-install build script.  Added some feedback to the build script to get a better idea of where the script might be hanging.

```
Build started
git config --global core.autocrlf true
git clone -q https://github.com/tunnelvisionlabs/antlr4cs.git C:\projects\antlr4cs
git fetch -q origin +refs/pull/120/merge:
git checkout -qf FETCH_HEAD
Running Install scripts
powershell -Command .\build\appveyor-install.ps1
```