### PR TITLE
FIX: BufferedTokenStream reusability

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime/BufferedTokenStream.cs
+++ b/runtime/CSharp/Antlr4.Runtime/BufferedTokenStream.cs
@@ -396,6 +396,7 @@ namespace Antlr4.Runtime
             this.tokenSource = tokenSource;
             tokens.Clear();
             p = -1;
+            fetchedEOF = false;
         }
 
         public virtual IList<IToken> GetTokens()


### PR DESCRIPTION
To reuse BufferedTokenStream via SetTokenSource() fetchedEOF must be reset to false to process any data from newly assigned source.
