### PR TITLE
Update the build task to support user-specified encodings

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
@@ -67,6 +67,7 @@
     <Antlr4>
       <Generator>MSBuild:Compile</Generator>
       <CustomToolNamespace>$(RootNamespace)</CustomToolNamespace>
+      <Encoding>UTF-8</Encoding>
       <TargetLanguage>CSharp</TargetLanguage>
       <Listener>true</Listener>
       <Visitor>true</Visitor>
@@ -118,6 +119,7 @@
       JavaExecutable="$(Antlr4JavaExecutable)"
       BuildTaskPath="$(Antlr4BuildTaskLocation)"
       OutputPath="$(IntermediateOutputPath)"
+      Encoding="%(Antlr4.Encoding)"
       TargetLanguage="%(Antlr4.TargetLanguage)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetNamespace="%(Antlr4.CustomToolNamespace)"

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
@@ -62,6 +62,7 @@
     <Antlr4>
       <Generator>MSBuild:Compile</Generator>
       <CustomToolNamespace>$(RootNamespace)</CustomToolNamespace>
+      <Encoding>UTF-8</Encoding>
       <TargetLanguage>CSharp</TargetLanguage>
       <Listener>true</Listener>
       <Visitor>true</Visitor>
@@ -113,6 +114,7 @@
       JavaExecutable="$(Antlr4JavaExecutable)"
       BuildTaskPath="$(Antlr4BuildTaskLocation)"
       OutputPath="$(IntermediateOutputPath)"
+      Encoding="%(Antlr4.Encoding)"
       TargetLanguage="%(Antlr4.TargetLanguage)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetNamespace="%(Antlr4.CustomToolNamespace)"

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
@@ -46,6 +46,12 @@ namespace Antlr4.Build.Tasks
             set;
         }
 
+        public string Encoding
+        {
+            get;
+            set;
+        }
+
         public string TargetLanguage
         {
             get;
@@ -305,6 +311,7 @@ namespace Antlr4.Build.Tasks
             wrapper.TargetLanguage = TargetLanguage;
             wrapper.TargetFrameworkVersion = TargetFrameworkVersion;
             wrapper.OutputPath = OutputPath;
+            wrapper.Encoding = Encoding;
             wrapper.LanguageSourceExtensions = LanguageSourceExtensions;
             wrapper.TargetNamespace = TargetNamespace;
             wrapper.GenerateListener = GenerateListener;

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -57,6 +57,12 @@ namespace Antlr4.Build.Tasks
             set;
         }
 
+        public string Encoding
+        {
+            get;
+            set;
+        }
+
         public string TargetNamespace
         {
             get;
@@ -254,6 +260,12 @@ namespace Antlr4.Build.Tasks
 
                 arguments.Add("-o");
                 arguments.Add(OutputPath);
+
+                if (!string.IsNullOrEmpty(Encoding))
+                {
+                    arguments.Add("-encoding");
+                    arguments.Add(Encoding);
+                }
 
                 if (GenerateListener)
                     arguments.Add("-listener");


### PR DESCRIPTION
> :warning: This pull request changes the *default* encoding used for grammar files from the system default to UTF-8.

Fixes #135