### PR TITLE
Rewrite the runtime test suite so it's fast enough to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ tool/target/
 
 # ignore NuGet output folders
 /build/nuget/
+
+# Ignore generated test suite
+Generated/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,15 @@ cache:
 - NETCFv35PowerToys.msi -> build\appveyor-install.ps1
 build_script:
 - cd build
-- powershell -Command .\build.ps1 -VisualStudioVersion "14.0" -Verbosity minimal -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" -Java6Home "${env:ProgramFiles}\Java\jdk1.7.0\jre"
+- powershell -Command .\build.ps1 -VisualStudioVersion "14.0" -Verbosity minimal -GenerateTests -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" -Java6Home "${env:ProgramFiles}\Java\jdk1.7.0\jre"
 - cd ..
-test: off
+test_script:
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net45\%CONFIGURATION%\Antlr4.Runtime.Test.net45.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\portable-net45\%CONFIGURATION%\Antlr4.Runtime.Test.portable_net45.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\portable-net40\%CONFIGURATION%\Antlr4.Runtime.Test.portable_net40.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net40\%CONFIGURATION%\Antlr4.Runtime.Test.net40_client.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net35\%CONFIGURATION%\Antlr4.Runtime.Test.net35_client.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net30\%CONFIGURATION%\Antlr4.Runtime.Test.net30.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net20\%CONFIGURATION%\Antlr4.Runtime.Test.net20.dll"
 artifacts:
 - path: build\nuget\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 os: Visual Studio 2015
-configuration: Debug
+configuration: Release
 init:
 - git config --global core.autocrlf true
 environment:

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -8,7 +8,8 @@ param (
 	[string]$MavenHome,
 	[string]$MavenRepo = "$($env:USERPROFILE)\.m2",
 	[switch]$SkipMaven,
-	[switch]$SkipKeyCheck
+	[switch]$SkipKeyCheck,
+	[switch]$GenerateTests
 )
 
 # build the solutions
@@ -116,8 +117,14 @@ If (-not $SkipMaven) {
 		exit 1
 	}
 
+	If ($GenerateTests) {
+		$SkipTestsArg = 'false'
+	} Else {
+		$SkipTestsArg = 'true'
+	}
+
 	$MavenGoal = 'package'
-	&$MavenPath '-B' '-DskipTests=true' '--errors' '-e' '-Dgpg.useagent=true' "-Djava6.home=$Java6Home" '-Psonatype-oss-release' $MavenGoal
+	&$MavenPath '-B' "-DskipTests=$SkipTestsArg" '--errors' '-e' '-Dgpg.useagent=true' "-Djava6.home=$Java6Home" '-Psonatype-oss-release' $MavenGoal
 	if (-not $?) {
 		$host.ui.WriteErrorLine('Maven build of the C# Target custom Tool failed, aborting!')
 		cd $OriginalPath

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net20.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net20.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net30.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net30.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net35-client.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net35-client.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net40-client.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net40-client.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net45.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.net45.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net40.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net40.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net45.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.portable-net45.csproj
@@ -62,7 +62,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="Generated\**\*.cs" Exclude="Generated\TestLexerExec\testLargeLexer\*.cs" />
     <Compile Include="JavaUnicodeInputStream.cs" />
+    <Compile Include="LexerTestOptions.cs" />
+    <Compile Include="ParserTestOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sharpen\Checksum.cs" />
     <Compile Include="Sharpen\CRC32.cs" />

--- a/runtime/CSharp/Antlr4.Runtime.Test/LexerTestOptions.cs
+++ b/runtime/CSharp/Antlr4.Runtime.Test/LexerTestOptions.cs
@@ -1,0 +1,45 @@
+﻿namespace Antlr4.Runtime.Test
+{
+    using System;
+
+    internal class LexerTestOptions
+    {
+        internal delegate TResult Factory<TArg, TResult>(TArg argument);
+
+        public string TestName
+        {
+            get;
+            set;
+        }
+
+        public Factory<ICharStream, Lexer> Lexer
+        {
+            get;
+            set;
+        }
+
+        public string Input
+        {
+            get;
+            set;
+        }
+
+        public string ExpectedOutput
+        {
+            get;
+            set;
+        }
+
+        public string ExpectedErrors
+        {
+            get;
+            set;
+        }
+
+        public bool ShowDFA
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/runtime/CSharp/Antlr4.Runtime.Test/ParserTestOptions.cs
+++ b/runtime/CSharp/Antlr4.Runtime.Test/ParserTestOptions.cs
@@ -1,0 +1,26 @@
+﻿namespace Antlr4.Runtime.Test
+{
+    using System;
+    using Antlr4.Runtime.Tree;
+
+    internal class ParserTestOptions<TParser> : LexerTestOptions
+    {
+        public Factory<ITokenStream, TParser> Parser
+        {
+            get;
+            set;
+        }
+
+        public Factory<TParser, IParseTree> ParserStartRule
+        {
+            get;
+            set;
+        }
+
+        public bool Debug
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/tool/src/org/antlr/v4/CSharpTool.java
+++ b/tool/src/org/antlr/v4/CSharpTool.java
@@ -32,6 +32,7 @@ package org.antlr.v4;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.HashMap;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
 
@@ -40,16 +41,30 @@ import org.antlr.v4.tool.Grammar;
  * @author Sam Harwell
  */
 public class CSharpTool extends Tool {
+	private boolean verbose = false;
 
 	public CSharpTool() {
+		this(null);
 	}
 
 	public CSharpTool(String[] args) {
 		super(args);
+		if (grammarEncoding == null) {
+			grammarEncoding = "UTF-8";
+		}
+
+		if (grammarOptions == null) {
+			grammarOptions = new HashMap<String, String>();
+		}
+
+		if (!grammarOptions.containsKey("language")) {
+			grammarOptions.put("language", "CSharp_v4_5");
+		}
 	}
 
 	public static void main(String[] args) {
-		Tool antlr = new CSharpTool(args);
+		CSharpTool antlr = new CSharpTool(args);
+		antlr.verbose = true;
 		if (args.length == 0) {
 			antlr.help();
 			antlr.exit(0);
@@ -87,7 +102,9 @@ public class CSharpTool extends Tool {
 			// for subdir/T.g4, you get subdir here.  Well, depends on -o etc...
 			File outputDir = getOutputDirectory(g.fileName);
 			File outputFile = new File(outputDir, fileName);
-			System.out.format("Generating file '%s' for grammar '%s'%n", outputFile.getAbsolutePath(), g.fileName);
+			if (this.verbose) {
+				System.out.format("Generating file '%s' for grammar '%s'%n", outputFile.getAbsolutePath(), g.fileName);
+			}
 		}
 
 		return super.getOutputFileWriter(g, fileName);

--- a/tool/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
@@ -29,40 +29,8 @@
  */
 package org.antlr.v4.test.runtime.csharp;
 
-import org.antlr.v4.Tool;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenSource;
-import org.antlr.v4.runtime.WritableToken;
-import org.antlr.v4.runtime.misc.Utils;
-import org.antlr.v4.tool.ANTLRMessage;
-import org.antlr.v4.tool.DefaultToolListener;
-import org.antlr.v4.tool.GrammarSemanticsMessage;
-import org.junit.Before;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-import org.stringtemplate.v4.ST;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathFactory;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,144 +40,68 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.antlr.v4.CSharpTool;
+import org.antlr.v4.Tool;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Utils;
+import org.antlr.v4.tool.ANTLRMessage;
+import org.antlr.v4.tool.DefaultToolListener;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+import org.stringtemplate.v4.ST;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public abstract class BaseTest {
+	public String tmpdir;
+	@Rule public TestName name = new TestName();
+	protected String input;
+	protected String expectedOutput;
+	protected String expectedErrors;
+	private String stderrDuringParse;
 	public static final String newline = System.getProperty("line.separator");
 	public static final String pathSep = System.getProperty("path.separator");
 
 	/**
-	 * When the {@code antlr.preserve-test-dir} runtime property is set to
-	 * {@code true}, the temporary directories created by the test run will not
-	 * be removed at the end of the test run, even for tests that completed
-	 * successfully.
-	 *
-	 * <p>
-	 * The default behavior (used in all other cases) is removing the temporary
-	 * directories for all tests which completed successfully, and preserving
-	 * the directories for tests which failed.</p>
+	 * Generates C# verbatim style Template String body (WITHOUT surrounding quotes)
 	 */
-	public static final boolean PRESERVE_TEST_DIR = Boolean.parseBoolean(System.getProperty("antlr-preserve-csharp-test-dir"));
-
-	/**
-	 * The base test directory is the directory where generated files get placed
-	 * during unit test execution.
-	 *
-	 * <p>
-	 * The default value for this property is the {@code java.io.tmpdir} system
-	 * property, and can be overridden by setting the
-	 * {@code antlr.java-test-dir} property to a custom location. Note that the
-	 * {@code antlr.java-test-dir} property directly affects the
-	 * {@link #CREATE_PER_TEST_DIRECTORIES} value as well.</p>
-	 */
-	public static final String BASE_TEST_DIR;
-
-	/**
-	 * When {@code true}, a temporary directory will be created for each test
-	 * executed during the test run.
-	 *
-	 * <p>
-	 * This value is {@code true} when the {@code antlr.java-test-dir} system
-	 * property is set, and otherwise {@code false}.</p>
-	 */
-	public static final boolean CREATE_PER_TEST_DIRECTORIES;
-
-	static {
-		String baseTestDir = System.getProperty("antlr-csharp-test-dir");
-		boolean perTestDirectories = false;
-		if (baseTestDir == null || baseTestDir.isEmpty()) {
-			baseTestDir = System.getProperty("java.io.tmpdir");
-			perTestDirectories = true;
-		}
-
-		if (!new File(baseTestDir).isDirectory()) {
-			throw new UnsupportedOperationException("The specified base test directory does not exist: " + baseTestDir);
-		}
-
-		BASE_TEST_DIR = baseTestDir;
-		CREATE_PER_TEST_DIRECTORIES = perTestDirectories;
+	private static String asTemplateString(String text) {
+		return text.replace("\"","\"\"");
 	}
 
-	public String tmpdir = null;
-
-	/** If error during parser execution, store stderr here; can't return
-     *  stdout and stderr.  This doesn't trap errors from running antlr.
-     */
-	protected String stderrDuringParse;
-
-	@org.junit.Rule
-	public final TestRule testWatcher = new TestWatcher() {
-
-		@Override
-		protected void succeeded(Description description) {
-			// remove tmpdir if no error.
-			if (!PRESERVE_TEST_DIR) {
-				eraseTempDir();
-			}
-		}
-
-	};
-
-    @Before
-	public void setUp() throws Exception {
-		if (CREATE_PER_TEST_DIRECTORIES) {
-			// new output dir for each test
-			String testDirectory = getClass().getSimpleName() + "-" + System.currentTimeMillis();
-			tmpdir = new File(BASE_TEST_DIR, testDirectory).getAbsolutePath();
-		}
-		else {
-			tmpdir = new File(BASE_TEST_DIR).getAbsolutePath();
-			if (!PRESERVE_TEST_DIR && new File(tmpdir).exists()) {
-				eraseFiles();
-			}
-		}
-    }
-
-    protected org.antlr.v4.Tool newTool(String[] args) {
-		Tool tool = new CSharpTool(args);
-		return tool;
-	}
-
-	protected Tool newTool() {
-		org.antlr.v4.Tool tool = new CSharpTool(new String[] {"-o", tmpdir});
-		return tool;
-	}
-
-	protected String load(String fileName, String encoding)
-		throws IOException
-	{
-		if ( fileName==null ) {
-			return null;
-		}
-
-		String fullFileName = getClass().getPackage().getName().replace('.', '/') + '/' + fileName;
-		int size = 65000;
-		InputStreamReader isr;
-		InputStream fis = getClass().getClassLoader().getResourceAsStream(fullFileName);
-		if ( encoding!=null ) {
-			isr = new InputStreamReader(fis, encoding);
-		}
-		else {
-			isr = new InputStreamReader(fis);
-		}
+	public static void writeFile(String dir, String fileName, String content) {
 		try {
-			char[] data = new char[size];
-			int n = isr.read(data);
-			return new String(data, 0, n);
+			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
 		}
-		finally {
-			isr.close();
+		catch (IOException ioe) {
+			System.err.println("can't write file");
+			ioe.printStackTrace(System.err);
 		}
 	}
 
+	@Before
+	public void setUp() throws Exception {
+		File cd = new File(".").getAbsoluteFile();
+		File baseDir = cd.getParentFile().getParentFile();
+		File classDir = new File(baseDir, "runtime/CSharp/Antlr4.Runtime.Test/Generated/" + getClass().getSimpleName());
+		File testDir = new File(classDir, name.getMethodName());
+		testDir.mkdirs();
+		for (File file : testDir.listFiles()) {
+			file.delete();
+		}
+		this.tmpdir = testDir.getAbsolutePath();
+	}
 
-	protected ErrorQueue antlr(String grammarFileName, boolean defaultListener, String... extraOptions) {
+    private org.antlr.v4.Tool newTool(String[] args) {
+		return new CSharpTool(args);
+	}
+
+	private ErrorQueue antlr(String grammarFileName, boolean defaultListener, String... extraOptions) {
 		final List<String> options = new ArrayList<String>();
 		Collections.addAll(options, extraOptions);
 		options.add("-Dlanguage=CSharp_v4_5");
+		options.add("-package");
+		options.add("Antlr4.Runtime.Test.Generated." + getClass().getSimpleName() + "._" + this.name.getMethodName().substring(4));
 		if ( !options.contains("-o") ) {
 			options.add("-o");
 			options.add(tmpdir);
@@ -260,25 +152,15 @@ public abstract class BaseTest {
 		return equeue;
 	}
 
-	protected ErrorQueue antlr(String grammarFileName, String grammarStr, boolean defaultListener, String... extraOptions) {
-		System.out.println("dir "+tmpdir);
+	private ErrorQueue antlr(String grammarFileName, String grammarStr, boolean defaultListener, String... extraOptions) {
 		mkdir(tmpdir);
 		writeFile(tmpdir, grammarFileName, grammarStr);
 		return antlr(grammarFileName, defaultListener, extraOptions);
 	}
 
-	protected String execLexer(String grammarFileName,
+	protected void generateLexerTest(String grammarFileName,
 							   String grammarStr,
 							   String lexerName,
-							   String input)
-	{
-		return execLexer(grammarFileName, grammarStr, lexerName, input, false);
-	}
-
-	protected String execLexer(String grammarFileName,
-							   String grammarStr,
-							   String lexerName,
-							   String input,
 							   boolean showDFA)
 	{
 		boolean success = rawGenerateRecognizer(grammarFileName,
@@ -286,33 +168,15 @@ public abstract class BaseTest {
 									  null,
 									  lexerName);
 		assertTrue(success);
-		writeFile(tmpdir, "input", input);
 		writeLexerTestFile(lexerName, showDFA);
-		addSourceFiles("Test.cs");
-		if(!compile()) {
-			System.err.println("Failed to compile!");
-			return stderrDuringParse;
-		}
-		String output = execTest();
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
-			System.err.println(stderrDuringParse);
-		}
-		return output;
 	}
 
-	Set<String> sourceFiles = new HashSet<String>();
-
-	private void addSourceFiles(String ... files) {
-		for(String file : files)
-			this.sourceFiles.add(file);
-	}
-
-	protected String execParser(String grammarFileName,
+	protected void generateParserTest(String grammarFileName,
 								String grammarStr,
 								String parserName,
 								String lexerName,
 								String startRuleName,
-								String input, boolean debug)
+								boolean debug)
 	{
 		boolean success = rawGenerateRecognizer(grammarFileName,
 														grammarStr,
@@ -320,15 +184,17 @@ public abstract class BaseTest {
 														lexerName,
 														"-visitor");
 		assertTrue(success);
-		writeFile(tmpdir, "input", input);
-		return rawExecRecognizer(parserName,
-								 lexerName,
-								 startRuleName,
-								 debug);
+		this.stderrDuringParse = null;
+		if (parserName == null) {
+			writeLexerTestFile(lexerName, false);
+		}
+		else {
+			writeParserTestFile(parserName, lexerName, startRuleName, debug);
+		}
 	}
 
 	/** Return true if all is well */
-	protected boolean rawGenerateRecognizer(String grammarFileName,
+	private boolean rawGenerateRecognizer(String grammarFileName,
 													String grammarStr,
 													String parserName,
 													String lexerName,
@@ -338,7 +204,7 @@ public abstract class BaseTest {
 	}
 
 	/** Return true if all is well */
-	protected boolean rawGenerateRecognizer(String grammarFileName,
+	private boolean rawGenerateRecognizer(String grammarFileName,
 													String grammarStr,
 													String parserName,
 													String lexerName,
@@ -367,327 +233,7 @@ public abstract class BaseTest {
 				files.add(grammarName+"BaseVisitor.cs");
 			}
 		}
-		addSourceFiles(files.toArray(new String[files.size()]));
 		return true;
-	}
-
-	protected String rawExecRecognizer(String parserName,
-									   String lexerName,
-									   String parserStartRuleName,
-									   boolean debug)
-	{
-        this.stderrDuringParse = null;
-		if ( parserName==null ) {
-			writeLexerTestFile(lexerName, false);
-		}
-		else {
-			writeParserTestFile(parserName,
-						  lexerName,
-						  parserStartRuleName,
-						  debug);
-		}
-
-		addSourceFiles("Test.cs");
-		return execRecognizer();
-	}
-
-	public String execRecognizer() {
-		compile();
-		return execTest();
-	}
-
-	public boolean compile() {
-		try {
-			if(!createProject())
-				return false;
-			if(!buildProject())
-				return false;
-			return true;
-		} catch(Exception e) {
-			return false;
-		}
-	}
-
-	private File getTestProjectFile() {
-		return new File(tmpdir, "Antlr4.Test.mono.csproj");
-	}
-
-	private boolean buildProject() throws Exception {
-		String msbuild = locateMSBuild();
-		String[] args = {
-				msbuild,
-				"/p:Configuration=Release",
-				"/p:SignAssembly=false",
-                "/p:BuildProjectReferences=false",
-				getTestProjectFile().getAbsolutePath()
-			};
-		System.err.println("Starting build "+ Utils.join(args, " "));
-		ProcessBuilder pb = new ProcessBuilder(args);
-		pb.directory(new File(tmpdir));
-		Process process = pb.start();
-		StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
-		StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
-		stdoutVacuum.start();
-		stderrVacuum.start();
-		process.waitFor();
-		stdoutVacuum.join();
-		stderrVacuum.join();
-		// xbuild sends errors to output, so check exit code
-		boolean success = process.exitValue()==0;
-		if ( !success ) {
-			this.stderrDuringParse = stdoutVacuum.toString();
-			System.err.println("buildProject stderrVacuum: "+ this.stderrDuringParse);
-		}
-		return success;
-	}
-
-	private String locateMSBuild() {
-		if(isWindows())
-			return "\"C:\\Program Files (x86)\\MSBuild\\12.0\\Bin\\MSBuild.exe\"";
-		else
-			return locateTool("xbuild");
-	}
-
-	private boolean isWindows() {
-		return System.getProperty("os.name").toLowerCase().contains("windows");
-	}
-
-	private String locateExec() {
-		return new File(tmpdir, "bin/Release/Test.exe").getAbsolutePath();
-	}
-
-	private String locateTool(String tool) {
-		String[] roots = { "/usr/bin/", "/usr/local/bin/" };
-		for(String root : roots) {
-			if(new File(root + tool).exists())
-				return root + tool;
-		}
-		throw new RuntimeException("Could not locate " + tool);
-	}
-
-	public boolean createProject() {
-		try {
-			String pack = BaseTest.class.getPackage().getName().replace(".", "/") + "/";
-			// save auxiliary files
-			saveResourceAsFile(pack + "AssemblyInfo.cs", new File(tmpdir, "AssemblyInfo.cs"));
-			saveResourceAsFile(pack + "App.config", new File(tmpdir, "App.config"));
-			// update project
-			String projectName = isWindows() ? "Antlr4.Test.vs2013.csproj" : "Antlr4.Test.mono.csproj";
-			final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-			InputStream input = loader.getResourceAsStream(pack + projectName);
-			Document prjXml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(input);
-			// update runtime project reference
-			// find project file as a resource not relative pathname (now that we've merged repos)
-			String runtimeName = isWindows() ? "Antlr4.Runtime.net45.csproj" : "Antlr4.Runtime.mono.csproj";
-			final URL runtimeProj = loader.getResource("CSharp/Antlr4.Runtime/"+runtimeName);
-			if ( runtimeProj==null ) {
-				throw new RuntimeException("C# runtime project file not found!");
-			}
-			String runtimeProjPath = new File(runtimeProj.toURI()).getAbsolutePath();
-			XPathExpression exp = XPathFactory.newInstance().newXPath()
-				.compile("/Project/ItemGroup/ProjectReference[@Include='" + runtimeName + "']");
-			Element node = (Element)exp.evaluate(prjXml, XPathConstants.NODE);
-			node.setAttribute("Include", runtimeProjPath.replace("/", "\\"));
-			// update project file list
-			exp = XPathFactory.newInstance().newXPath().compile("/Project/ItemGroup[Compile/@Include='AssemblyInfo.cs']");
-			Element group = (Element)exp.evaluate(prjXml, XPathConstants.NODE);
-			if(group==null)
-				return false;
-			// remove existing children
-			while(group.hasChildNodes())
-				group.removeChild(group.getFirstChild());
-			// add AssemblyInfo.cs, not a generated source
-			sourceFiles.add("AssemblyInfo.cs");
-			// add files to compile
-			for(String file : sourceFiles) {
-				Element elem = group.getOwnerDocument().createElement("Compile");
-				elem.setAttribute("Include", file);
-				group.appendChild(elem);
-			}
-			// save project
-			File prjFile = getTestProjectFile();
-			Transformer transformer = TransformerFactory.newInstance().newTransformer();
-			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.transform(new DOMSource(prjXml), new StreamResult(prjFile));
-			return true;
-		} catch(Exception e) {
-			e.printStackTrace(System.err);
-			return false;
-		}
-	}
-
-	private void saveResourceAsFile(String resourceName, File file) throws IOException {
-		InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
-		if ( input==null ) {
-			System.err.println("Can't find " + resourceName + " as resource");
-			throw new IOException("Missing resource:" + resourceName);
-		}
-		OutputStream output = new FileOutputStream(file.getAbsolutePath());
-		while(input.available()>0) {
-			output.write(input.read());
-		}
-		output.close();
-		input.close();
-	}
-
-	public String execTest() {
-		try {
-			String exec = locateExec();
-			String[] args = isWindows() ?
-					new String[] { exec, new File(tmpdir, "input").getAbsolutePath() } :
-					new String[] { "mono", exec, new File(tmpdir, "input").getAbsolutePath() };
-			ProcessBuilder pb = new ProcessBuilder(args);
-			pb.directory(new File(tmpdir));
-			Process process = pb.start();
-			StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
-			StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
-			stdoutVacuum.start();
-			stderrVacuum.start();
-			process.waitFor();
-			stdoutVacuum.join();
-			stderrVacuum.join();
-			String output = stdoutVacuum.toString();
-			if ( stderrVacuum.toString().length()>0 ) {
-				this.stderrDuringParse = stderrVacuum.toString();
-				System.err.println("exec stderrVacuum: "+ stderrVacuum);
-			}
-			return output;
-		}
-		catch (Exception e) {
-			System.err.println("can't exec recognizer");
-			e.printStackTrace(System.err);
-		}
-		return null;
-	}
-
-	public void testErrors(String[] pairs, boolean printTree) {
-        for (int i = 0; i < pairs.length; i+=2) {
-            String input = pairs[i];
-            String expect = pairs[i+1];
-
-			String[] lines = input.split("\n");
-			String fileName = getFilenameFromFirstLineOfGrammar(lines[0]);
-			ErrorQueue equeue = antlr(fileName, input, false);
-
-			String actual = equeue.toString(true);
-			actual = actual.replace(tmpdir + File.separator, "");
-			System.err.println(actual);
-			String msg = input;
-			msg = msg.replace("\n","\\n");
-			msg = msg.replace("\r","\\r");
-			msg = msg.replace("\t","\\t");
-
-			org.junit.Assert.assertEquals("error in: "+msg,expect,actual);
-        }
-    }
-
-	public String getFilenameFromFirstLineOfGrammar(String line) {
-		String fileName = "A" + Tool.GRAMMAR_EXTENSION;
-		int grIndex = line.lastIndexOf("grammar");
-		int semi = line.lastIndexOf(';');
-		if ( grIndex>=0 && semi>=0 ) {
-			int space = line.indexOf(' ', grIndex);
-			fileName = line.substring(space+1, semi)+Tool.GRAMMAR_EXTENSION;
-		}
-		if ( fileName.length()==Tool.GRAMMAR_EXTENSION.length() ) fileName = "A" + Tool.GRAMMAR_EXTENSION;
-		return fileName;
-	}
-
-
-	List<ANTLRMessage> getMessagesOfType(List<ANTLRMessage> msgs, Class<? extends ANTLRMessage> c) {
-		List<ANTLRMessage> filtered = new ArrayList<ANTLRMessage>();
-		for (ANTLRMessage m : msgs) {
-			if ( m.getClass() == c ) filtered.add(m);
-		}
-		return filtered;
-	}
-
-
-	public static class StreamVacuum implements Runnable {
-		StringBuilder buf = new StringBuilder();
-		BufferedReader in;
-		Thread sucker;
-		public StreamVacuum(InputStream in) {
-			this.in = new BufferedReader( new InputStreamReader(in) );
-		}
-		public void start() {
-			sucker = new Thread(this);
-			sucker.start();
-		}
-		@Override
-		public void run() {
-			try {
-				String line = in.readLine();
-				while (line!=null) {
-					buf.append(line);
-					buf.append('\n');
-					line = in.readLine();
-				}
-			}
-			catch (IOException ioe) {
-				System.err.println("can't read output from process");
-			}
-		}
-		/** wait for the thread to finish */
-		public void join() throws InterruptedException {
-			sucker.join();
-		}
-		@Override
-		public String toString() {
-			return buf.toString();
-		}
-	}
-
-	protected void checkGrammarSemanticsError(ErrorQueue equeue,
-											  GrammarSemanticsMessage expectedMessage)
-		throws Exception
-	{
-		ANTLRMessage foundMsg = null;
-		for (int i = 0; i < equeue.errors.size(); i++) {
-			ANTLRMessage m = equeue.errors.get(i);
-			if (m.getErrorType()==expectedMessage.getErrorType() ) {
-				foundMsg = m;
-			}
-		}
-		assertNotNull("no error; "+expectedMessage.getErrorType()+" expected", foundMsg);
-		assertTrue("error is not a GrammarSemanticsMessage",
-				   foundMsg instanceof GrammarSemanticsMessage);
-		assertEquals(Arrays.toString(expectedMessage.getArgs()), Arrays.toString(foundMsg.getArgs()));
-		if ( equeue.size()!=1 ) {
-			System.err.println(equeue);
-		}
-	}
-
-
-    public static class FilteringTokenStream extends CommonTokenStream {
-        public FilteringTokenStream(TokenSource src) { super(src); }
-        Set<Integer> hide = new HashSet<Integer>();
-        @Override
-        protected boolean sync(int i) {
-            if (!super.sync(i)) {
-				return false;
-			}
-
-			Token t = get(i);
-			if ( hide.contains(t.getType()) ) {
-				((WritableToken)t).setChannel(Token.HIDDEN_CHANNEL);
-			}
-
-			return true;
-        }
-        public void setTokenTypeChannel(int ttype, int channel) {
-            hide.add(ttype);
-        }
-    }
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
 	}
 
 	protected void mkdir(String dir) {
@@ -695,150 +241,121 @@ public abstract class BaseTest {
 		f.mkdirs();
 	}
 
-	protected void writeParserTestFile(String parserName,
+	private void writeParserTestFile(String parserName,
 								 String lexerName,
 								 String parserStartRuleName,
 								 boolean debug)
 	{
+//		ST outputFileST = new ST(
+//			"using System;\n" +
+//			"using Antlr4.Runtime;\n" +
+//			"using Antlr4.Runtime.Tree;\n" +
+//			"\n" +
+//			"public class Test {\n" +
+//			"    public static void Main(string[] args) {\n" +
+//			"        ICharStream input = new AntlrFileStream(args[0]);\n" +
+//			"        <lexerName> lex = new <lexerName>(input);\n" +
+//			"        CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
+//			"        <createParser>\n"+
+//			"		 parser.BuildParseTree = true;\n" +
+//			"        ParserRuleContext tree = parser.<parserStartRuleName>();\n" +
+//			"        ParseTreeWalker.Default.Walk(new TreeShapeListener(), tree);\n" +
+//			"    }\n" +
+//			"}\n" +
+//			"\n" +
+//			"class TreeShapeListener : IParseTreeListener {\n" +
+//			"	public void VisitTerminal(ITerminalNode node) { }\n" +
+//			"	public void VisitErrorNode(IErrorNode node) { }\n" +
+//			"	public void ExitEveryRule(ParserRuleContext ctx) { }\n" +
+//			"\n" +
+//			"	public void EnterEveryRule(ParserRuleContext ctx) {\n" +
+//			"		for (int i = 0; i \\< ctx.ChildCount; i++) {\n" +
+//			"			IParseTree parent = ctx.GetChild(i).Parent;\n" +
+//			"			if (!(parent is IRuleNode) || ((IRuleNode)parent).RuleContext != ctx) {\n" +
+//			"				throw new Exception(\"Invalid parse tree shape detected.\");\n" +
+//			"			}\n" +
+//			"		}\n" +
+//			"	}\n" +
+//			"}"
+//			);
+//        ST createParserST = new ST("        <parserName> parser = new <parserName>(tokens);\n");
+//		if ( debug ) {
+//			createParserST =
+//				new ST(
+//				"        <parserName> parser = new <parserName>(tokens);\n" +
+//				"        parser.Interpreter.reportAmbiguities = true;\n" +
+//                "        parser.AddErrorListener(new DiagnosticErrorListener());\n");
+//		}
+//		outputFileST.add("createParser", createParserST);
+//		outputFileST.add("parserName", parserName);
+//		outputFileST.add("lexerName", lexerName);
+//		outputFileST.add("parserStartRuleName", parserStartRuleName);
 		ST outputFileST = new ST(
-			"using System;\n" +
-			"using Antlr4.Runtime;\n" +
-			"using Antlr4.Runtime.Tree;\n" +
-			"\n" +
-			"public class Test {\n" +
-			"    public static void Main(string[] args) {\n" +
-			"        ICharStream input = new AntlrFileStream(args[0]);\n" +
-			"        <lexerName> lex = new <lexerName>(input);\n" +
-			"        CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
-			"        <createParser>\n"+
-			"		 parser.BuildParseTree = true;\n" +
-			"        ParserRuleContext tree = parser.<parserStartRuleName>();\n" +
-			"        ParseTreeWalker.Default.Walk(new TreeShapeListener(), tree);\n" +
-			"    }\n" +
-			"}\n" +
-			"\n" +
-			"class TreeShapeListener : IParseTreeListener {\n" +
-			"	public void VisitTerminal(ITerminalNode node) { }\n" +
-			"	public void VisitErrorNode(IErrorNode node) { }\n" +
-			"	public void ExitEveryRule(ParserRuleContext ctx) { }\n" +
-			"\n" +
-			"	public void EnterEveryRule(ParserRuleContext ctx) {\n" +
-			"		for (int i = 0; i \\< ctx.ChildCount; i++) {\n" +
-			"			IParseTree parent = ctx.GetChild(i).Parent;\n" +
-			"			if (!(parent is IRuleNode) || ((IRuleNode)parent).RuleContext != ctx) {\n" +
-			"				throw new Exception(\"Invalid parse tree shape detected.\");\n" +
-			"			}\n" +
-			"		}\n" +
-			"	}\n" +
-			"}"
-			);
-        ST createParserST = new ST("        <parserName> parser = new <parserName>(tokens);\n");
-		if ( debug ) {
-			createParserST =
-				new ST(
-				"        <parserName> parser = new <parserName>(tokens);\n" +
-				"        parser.Interpreter.reportAmbiguities = true;\n" +
-                "        parser.AddErrorListener(new DiagnosticErrorListener());\n");
-		}
-		outputFileST.add("createParser", createParserST);
+				"using Microsoft.VisualStudio.TestTools.UnitTesting;\n" +
+				"\n" +
+				"namespace Antlr4.Runtime.Test.Generated.<className>._<testName> {\n" +
+				"[TestClass] public class Test : BaseTest {\n" +
+				"[TestMethod] [TestCategory(\"runtime-suite\")] public void Test<testName>() {\n" +
+				"	base.ParserTest(new ParserTestOptions\\< <parserName> > {\n" +
+				"		TestName = \"<testName>\",\n" +
+				"		Lexer = input => new <lexerName>(input),\n" +
+				"		Parser = tokens => new <parserName>(tokens),\n" +
+				"		ParserStartRule = parser => parser.<parserStartRuleName>(),\n" +
+				"		Debug = <debug>,\n" +
+				"		Input = @\"<input>\",\n" +
+				"		ExpectedOutput = @\"<expectedOutput>\",\n" +
+				"		ExpectedErrors = @\"<expectedErrors>\",\n" +
+				"		ShowDFA = <showDFA>\n" +
+				"		});\n" +
+				"	}\n" +
+				"}\n" +
+				"}\n");
+
+		outputFileST.add("className", getClass().getSimpleName());
+		outputFileST.add("testName", this.name.getMethodName().substring(4));
+		outputFileST.add("lexerName", lexerName);
 		outputFileST.add("parserName", parserName);
-		outputFileST.add("lexerName", lexerName);
-		outputFileST.add("parserStartRuleName", parserStartRuleName);
+		outputFileST.add("parserStartRuleName", asTemplateString(parserStartRuleName));
+		outputFileST.add("debug", debug ? "true" : "false");
+		outputFileST.add("input", asTemplateString(this.input));
+		outputFileST.add("expectedOutput", asTemplateString(this.expectedOutput));
+		outputFileST.add("expectedErrors", asTemplateString(this.expectedErrors));
+		outputFileST.add("showDFA", "false");
 		writeFile(tmpdir, "Test.cs", outputFileST.render());
 	}
 
-	protected void writeLexerTestFile(String lexerName, boolean showDFA) {
+	private void writeLexerTestFile(String lexerName, boolean showDFA) {
 		ST outputFileST = new ST(
-			"using System;\n" +
-			"using Antlr4.Runtime;\n" +
-			"\n" +
-			"public class Test {\n" +
-			"    public static void Main(string[] args) {\n" +
-			"        ICharStream input = new AntlrFileStream(args[0]);\n" +
-			"        <lexerName> lex = new <lexerName>(input);\n" +
-			"        CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
-			"        tokens.Fill();\n" +
-			"        foreach (object t in tokens.GetTokens())\n" +
-			"			Console.WriteLine(t);\n" +
-			(showDFA?"Console.Write(lex.Interpreter.GetDFA(Lexer.DefaultMode).ToLexerString());\n":"")+
-			"    }\n" +
-			"}"
-			);
+				"using Microsoft.VisualStudio.TestTools.UnitTesting;\n" +
+				"\n" +
+				"namespace Antlr4.Runtime.Test.Generated.<className>._<testName> {\n" +
+				"[TestClass] public class Test : BaseTest {\n" +
+				"[TestMethod] [TestCategory(\"runtime-suite\")] public void Test<testName>() {\n" +
+				"	base.LexerTest(new LexerTestOptions {\n" +
+				"		TestName = \"<testName>\",\n" +
+				"		Lexer = input => new <lexerName>(input),\n" +
+				"		Input = @\"<input>\",\n" +
+				"		ExpectedOutput = @\"<expectedOutput>\",\n" +
+				"		ExpectedErrors = @\"<expectedErrors>\",\n" +
+				"		ShowDFA = <showDFA>\n" +
+				"		});\n" +
+				"	}\n" +
+				"}\n" +
+				"}\n");
 
+		outputFileST.add("className", getClass().getSimpleName());
+		outputFileST.add("testName", this.name.getMethodName().substring(4));
 		outputFileST.add("lexerName", lexerName);
+		outputFileST.add("input", asTemplateString(this.input));
+		outputFileST.add("expectedOutput", asTemplateString(this.expectedOutput));
+		outputFileST.add("expectedErrors", asTemplateString(this.expectedErrors));
+		outputFileST.add("showDFA", showDFA ? "true" : "false");
 		writeFile(tmpdir, "Test.cs", outputFileST.render());
-	}
-
-	public void writeRecognizerAndCompile(String parserName, String lexerName,
-										  String parserStartRuleName,
-										  boolean debug) {
-		if ( parserName==null ) {
-			writeLexerTestFile(lexerName, debug);
-		}
-		else {
-			writeParserTestFile(parserName,
-						  lexerName,
-						  parserStartRuleName,
-						  debug);
-		}
-
-		addSourceFiles("Test.cs");
-	}
-
-
-    protected void eraseFiles(final String filesEndingWith) {
-        File tmpdirF = new File(tmpdir);
-        String[] files = tmpdirF.list();
-        for(int i = 0; files!=null && i < files.length; i++) {
-            if ( files[i].endsWith(filesEndingWith) ) {
-                new File(tmpdir+"/"+files[i]).delete();
-            }
-        }
-    }
-
-    protected void eraseFiles() {
-		if (tmpdir == null) {
-			return;
-		}
-
-        File tmpdirF = new File(tmpdir);
-        String[] files = tmpdirF.list();
-        if(files!=null) for(String file : files) {
-        	new File(tmpdir+"/"+file).delete();
-        }
-    }
-
-    protected void eraseTempDir() {
-        File tmpdirF = new File(tmpdir);
-        if ( tmpdirF.exists() ) {
-            eraseFiles();
-            tmpdirF.delete();
-        }
-    }
-
-	public String getFirstLineOfException() {
-		if ( this.stderrDuringParse ==null ) {
-			return null;
-		}
-		String[] lines = this.stderrDuringParse.split("\n");
-		String prefix="Exception in thread \"main\" ";
-		return lines[0].substring(prefix.length(),lines[0].length());
 	}
 
 	public List<String> realElements(List<String> elements) {
 		return elements.subList(Token.MIN_USER_TOKEN_TYPE, elements.size());
 	}
-
-	public void assertNotNullOrEmpty(String message, String text) {
-		assertNotNull(message, text);
-		assertFalse(message, text.isEmpty());
-	}
-
-	public void assertNotNullOrEmpty(String text) {
-		assertNotNull(text);
-		assertFalse(text.isEmpty());
-	}
-
 
 	/** Return map sorted by key */
 	public <K extends Comparable<? super K>,V> LinkedHashMap<K,V> sort(Map<K,V> data) {
@@ -851,17 +368,4 @@ public abstract class BaseTest {
 		}
 		return dup;
 	}
-
-	protected static void assertEquals(String msg, int a, int b) {
-		org.junit.Assert.assertEquals(msg, a, b);
-	}
-
-	protected static void assertEquals(String a, String b) {
-		org.junit.Assert.assertEquals(a, b);
-	}
-
-	protected static void assertNull(String a) {
-		org.junit.Assert.assertNull(a);
-	}
-
 }

--- a/tool/test/org/antlr/v4/test/runtime/csharp/CSharp.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/csharp/CSharp.test.stg
@@ -36,14 +36,10 @@ public void test<test.name>() throws Exception {
 <if(test.AfterGrammar)>
 	<test.AfterGrammar>
 <endif>
-	String input =<writeStringLiteral(test.Input)>;
-	String found = execLexer("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", input, <writeBoolean(test.Options.("ShowDFA"))>);
-	assertEquals(<writeStringLiteral(test.Output)>, found);
-	<if(!isEmpty.(test.Errors))>
-	assertEquals(<writeStringLiteral(test.Errors)>, this.stderrDuringParse);
-	<else>
-	assertNull(this.stderrDuringParse);
-	<endif>
+	this.input = <writeStringLiteral(test.Input)>;
+	this.expectedOutput = <writeStringLiteral(test.Output)>;
+	this.expectedErrors = <writeStringLiteral(test.Errors)>;
+	generateLexerTest("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", <writeBoolean(test.Options.("ShowDFA"))>);
 	}>
 }
 
@@ -71,14 +67,10 @@ public void test<test.name>() throws Exception {
 
 	<test.AfterGrammar>
 
-	String input =<writeStringLiteral(test.Input)>;
-	String found = execParser("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", input, <writeBoolean(test.Options.("Debug"))>);
-	assertEquals(<writeStringLiteral(test.Output)>, found);
-	<if(!isEmpty.(test.Errors))>
-	assertEquals(<writeStringLiteral(test.Errors)>, this.stderrDuringParse);
-	<else>
-	assertNull(this.stderrDuringParse);
-	<endif>
+	this.input =<writeStringLiteral(test.Input)>;
+	this.expectedOutput = <writeStringLiteral(test.Output)>;
+	this.expectedErrors = <writeStringLiteral(test.Errors)>;
+	generateParserTest("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", <writeBoolean(test.Options.("Debug"))>);
 	}>
 }
 
@@ -91,7 +83,7 @@ CompositeParserTestMethod(test) ::= <<
 AbstractParserTestMethod(test) ::= <<
 String test<test.name>(String input) throws Exception {
 	String grammar = <test.grammar.lines:{ line | "<line>};separator="\\n\" +\n", wrap, anchor>";
-	return execParser("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", input, <test.debug>);
+	return generateParserTest("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", input, <test.debug>);
 }
 
 >>
@@ -234,7 +226,7 @@ ImportBailErrorStrategy() ::= ""
 GetExpectedTokenNames() ::= "this.GetExpectedTokens().ToString(Vocabulary)"
 
 RuleInvocationStack() ::= <%
-"[" + string.Join(", ", GetRuleInvocationStack()) + "]"
+"[" + Utils.Join(", ", GetRuleInvocationStack()) + "]"
 %>
 
 FULL_CONTEXT_DFA() ::= "Interpreter.enable_global_context_dfa = true;"


### PR DESCRIPTION
Run the test suite in C# instead of Java

This commit updates the test suite to only generate C# code. The compilation and execution of the test code is left for the various Antlr4.Runtime.Test projects. The strategy results in a 20x improvement for generating and executing the test suite, and over a 100x improvement for rerunning tests without generating them again.

This work is heavily based on the approach used by @BurtHarris in tunnelvisionlabs/antlr4ts#244.