### PR TITLE
Remove the use of a separate AppDomain in the build task

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
@@ -6,11 +6,8 @@ namespace Antlr4.Build.Tasks
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
-    using System.Security;
-    using System.Security.Policy;
     using System.Threading;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -10,9 +10,9 @@ namespace Antlr4.Build.Tasks
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
-    using RegistryHive = Microsoft.Win32.RegistryHive;
     using RegistryKey = Microsoft.Win32.RegistryKey;
 #if NET40PLUS
+    using RegistryHive = Microsoft.Win32.RegistryHive;
     using RegistryView = Microsoft.Win32.RegistryView;
 #else
     using Registry = Microsoft.Win32.Registry;

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -19,7 +19,7 @@ namespace Antlr4.Build.Tasks
 #endif
     using StringBuilder = System.Text.StringBuilder;
 
-    internal class AntlrClassGenerationTaskInternal : MarshalByRefObject
+    internal class AntlrClassGenerationTaskInternal
     {
         private List<string> _generatedCodeFiles = new List<string>();
         private IList<string> _sourceCodeFiles = new List<string>();


### PR DESCRIPTION
The `AppDomain` was originally used in the ANTLR 3 C# release, before NuGet was a thing. By referencing only a shadow-copied build of the ANTLR tool, the `AppDomain` prevented Visual Studio from locking the build binaries on disk, leading to source control problems. Now that the build files are managed by NuGet, and NuGet handles locked files in a clean manner, the use of `AppDomain` for isolation no longer appears necessary.

Removal of the use of `AppDomain` immediately fixes the incompatibility with Visual Studio 2017, and paves the way for a new MSBuild integration that works across platforms that support .NET Standard, including Mono (XBuild) and .NET Core (MSBuild) on non-Windows systems.

Fixes #173