### PR TITLE
Validate the build works with both dotnet and MSBuild

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 version: 1.0.{build}
-os: Visual Studio 2017
+os: Visual Studio 2017 Preview
 configuration: Release
 init:
 - git config --global core.autocrlf true
 build_script:
 - cd build
-- powershell -Command .\build.ps1 -VisualStudioVersion "15.0" -Verbosity minimal -GenerateTests -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" -Java6Home "${env:ProgramFiles}\Java\jdk1.7.0\jre"
+- powershell -Command .\build.ps1 -VisualStudioVersion "15.0" -Verbosity minimal -GenerateTests -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" -Java6Home "${env:ProgramFiles}\Java\jdk1.7.0\jre" -Validate
 - cd ..
 test_script:
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\net45\%CONFIGURATION%\Antlr4.Runtime.Test.net45.dll"

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -2,11 +2,37 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net20;net30;net35;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
+    <TargetFrameworks>net20;net30;net35;net35-cf;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
   </PropertyGroup>
 
   <Choose>
+    <When Condition="'$(TargetFramework)' == 'net35-cf'">
+      <PropertyGroup>
+        <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+        <TargetFrameworkProfile>CompactFramework</TargetFrameworkProfile>
+        <PlatformFamilyName>WindowsCE</PlatformFamilyName>
+        <DisableImplicitFrameworkReferences>True</DisableImplicitFrameworkReferences>
+        <AddAdditionalExplicitAssemblyReferences>False</AddAdditionalExplicitAssemblyReferences>
+        <NoStdLib>True</NoStdLib>
+        <NoConfig>True</NoConfig>
+        <DefineConstants>$(DefineConstants);$(PlatformFamilyName);COMPACT</DefineConstants>
+
+        <!-- Explicitly specify the location of framework reference assemblies -->
+        <_TargetFrameworkDirectories>..\..\runtime\CSharp\build\ReferenceAssemblies</_TargetFrameworkDirectories>
+        <_FullFrameworkReferenceAssemblyPaths>..\..\runtime\CSharp\build\ReferenceAssemblies</_FullFrameworkReferenceAssemblyPaths>
+
+        <!-- Disable assembly attributes not supported by this target -->
+        <TargetingClr2Framework>True</TargetingClr2Framework>
+        <GenerateAssemblyFileVersionAttribute>False</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>False</GenerateAssemblyInformationalVersionAttribute>
+      </PropertyGroup>
+      <ItemGroup>
+        <Reference Include="mscorlib" />
+        <Reference Include="System" />
+      </ItemGroup>
+    </When>
     <When Condition="'$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81'">
       <PropertyGroup>
         <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp1.1;net45</TargetFrameworks>
+    <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Antlr4" Version="4.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Antlr4 Include="Grammar.g4">
+      <CustomToolNamespace>DotnetValidation</CustomToolNamespace>
+      <Generator>MSBuild:Compile</Generator>
+    </Antlr4>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="@(Antlr4)" />
+  </ItemGroup>
+</Project>

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4" Version="4.6.2" />
+    <PackageReference Include="Antlr4" Version="4.6.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -47,7 +47,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4" Version="4.6.4" />
+    <PackageReference Include="Antlr4" Version="4.6.5-dev" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -2,9 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;net45</TargetFrameworks>
+    <TargetFrameworks>net20;net30;net35;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81'">
+      <PropertyGroup>
+        <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+        <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
+        <DefineConstants>$(DefineConstants);LEGACY_PCL</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <Reference Include="System" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <PackageReference Include="Antlr4" Version="4.6.4" />

--- a/build/DotnetValidation/DotnetValidation.sln
+++ b/build/DotnetValidation/DotnetValidation.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26621.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotnetValidation", "DotnetValidation.csproj", "{E1557B8D-28E5-4D82-AD1F-F483CD8ED931}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E1557B8D-28E5-4D82-AD1F-F483CD8ED931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1557B8D-28E5-4D82-AD1F-F483CD8ED931}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1557B8D-28E5-4D82-AD1F-F483CD8ED931}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1557B8D-28E5-4D82-AD1F-F483CD8ED931}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AAF2BF57-B4C1-49FA-AE88-6AC0DE5A9F1F}
+	EndGlobalSection
+EndGlobal

--- a/build/DotnetValidation/Grammar.g4
+++ b/build/DotnetValidation/Grammar.g4
@@ -1,0 +1,9 @@
+grammar Grammar;
+
+compilationUnit
+	:	'text' EOF
+	;
+
+WS
+	:	[ \t\r\n]+ -> skip
+	;

--- a/build/DotnetValidation/Program.cs
+++ b/build/DotnetValidation/Program.cs
@@ -13,7 +13,16 @@ namespace DotnetValidation
             var parser = new GrammarParser(new CommonTokenStream(lexer));
             var tree = parser.compilationUnit();
 
-            Console.WriteLine(tree.ToStringTree(parser));
+            Action<string> writeLine;
+
+#if LEGACY_PCL
+            var writeLineMethod = typeof(int).Assembly.GetType("Console").GetMethod("WriteLine", new[] { typeof(string) });
+            writeLine = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), writeLineMethod);
+#else
+            writeLine = Console.WriteLine;
+#endif
+
+            writeLine(tree.ToStringTree(parser));
         }
     }
 }

--- a/build/DotnetValidation/Program.cs
+++ b/build/DotnetValidation/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Antlr4.Runtime;
+
+[assembly: CLSCompliant(false)]
+
+namespace DotnetValidation
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var lexer = new GrammarLexer(new AntlrInputStream("text"));
+            var parser = new GrammarParser(new CommonTokenStream(lexer));
+            var tree = parser.compilationUnit();
+
+            Console.WriteLine(tree.ToStringTree(parser));
+        }
+    }
+}

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -185,15 +185,17 @@ ForEach ($package in $packages) {
 }
 
 If ($Validate) {
+	$LocalNuGetSource = '.\nuget'
+
 	git 'clean' '-dxf' 'DotnetValidation'
-	dotnet 'run' '--project' '.\DotnetValidation\DotnetValidation.csproj' '--framework' 'netcoreapp1.1'
+	dotnet 'run' '--source' $LocalNuGetSource '--project' '.\DotnetValidation\DotnetValidation.csproj' '--framework' 'netcoreapp1.1'
 	if (-not $?) {
 		$host.ui.WriteErrorLine('Build failed, aborting!')
 		Exit $LASTEXITCODE
 	}
 
 	git 'clean' '-dxf' 'DotnetValidation'
-	nuget restore DotnetValidation
+	nuget 'restore' 'DotnetValidation' '-source' $LocalNuGetSource
 	&$msbuild '/nologo' '/m' '/nr:false' '/t:Rebuild' $LoggerArgument "/verbosity:$Verbosity" "/p:Configuration=$BuildConfig" '.\DotnetValidation\DotnetValidation.sln'
 	if (-not $?) {
 		$host.ui.WriteErrorLine('Build failed, aborting!')

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -200,6 +200,36 @@ If ($Validate) {
 		Exit $LASTEXITCODE
 	}
 
+	".\DotnetValidation\bin\$BuildConfig\net20\DotnetValidation.exe"
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	".\DotnetValidation\bin\$BuildConfig\net30\DotnetValidation.exe"
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	".\DotnetValidation\bin\$BuildConfig\net35\DotnetValidation.exe"
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	".\DotnetValidation\bin\$BuildConfig\net40\DotnetValidation.exe"
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	".\DotnetValidation\bin\$BuildConfig\portable40-net40+sl5+win8+wp8+wpa81\DotnetValidation.exe"
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
 	".\DotnetValidation\bin\$BuildConfig\net45\DotnetValidation.exe"
 	if (-not $?) {
 		$host.ui.WriteErrorLine('Build failed, aborting!')


### PR DESCRIPTION
After an almost comical number of builds, the goal is to have commits that show the following, in order:

* [x] 1f6d2b1ea155372cc396f630ca8993e6e1520ff5: A build against 4.6.2 passes a `dotnet build` build fails in the MSBuild step (reproduces #216) 
* [x] 0d1b9cab2b5ce5dc187eb7c7c72ef5d8497fbc33: Updating to 4.6.4 fixes the problem (verifies #218)
* [x] e96bb26becd535c73d4f2dc4bf441cf3a7b8285c: Make the project cross-targeting, showing a successful build for all supported targets
* [x] 2228fd786f29b48ff39db3e7673122dc597199ff: Finally, update to a parameterized version and install the output of the current local build
