### PR TITLE
Fix design time builds under the new project system

### DIFF
--- a/build/version.ps1
+++ b/build/version.ps1
@@ -1,1 +1,1 @@
-$AntlrVersion = "4.6.4"
+$AntlrVersion = "4.6.5-dev"

--- a/build/version.ps1
+++ b/build/version.ps1
@@ -1,1 +1,1 @@
-$AntlrVersion = "4.6.4-dev"
+$AntlrVersion = "4.6.4"

--- a/runtime/CSharp/Antlr4.Runtime/Properties/AssemblyInfo.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Properties/AssemblyInfo.cs
@@ -44,5 +44,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("4.6.0.0")]
 #if !COMPACT
 [assembly: AssemblyFileVersion("4.6.4.0")]
-[assembly: AssemblyInformationalVersion("4.6.4-dev")]
+[assembly: AssemblyInformationalVersion("4.6.4")]
 #endif

--- a/runtime/CSharp/Antlr4.Runtime/Properties/AssemblyInfo.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Properties/AssemblyInfo.cs
@@ -43,6 +43,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.6.0.0")]
 #if !COMPACT
-[assembly: AssemblyFileVersion("4.6.4.0")]
-[assembly: AssemblyInformationalVersion("4.6.4")]
+[assembly: AssemblyFileVersion("4.6.5.0")]
+[assembly: AssemblyInformationalVersion("4.6.5-dev")]
 #endif

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.props
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.props
@@ -4,6 +4,6 @@
     <!-- Folder containing Antlr4BuildTasks.dll -->
     <Antlr4BuildTaskPath>.</Antlr4BuildTaskPath>
     <!-- Path to the ANTLR tool itself -->
-    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolPath>
+    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.5-SNAPSHOT-complete.jar</Antlr4ToolPath>
   </PropertyGroup>
 </Project>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.props
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.props
@@ -4,6 +4,6 @@
     <!-- Folder containing Antlr4BuildTasks.dll -->
     <Antlr4BuildTaskPath>.</Antlr4BuildTaskPath>
     <!-- Path to the ANTLR tool itself -->
-    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-SNAPSHOT-complete.jar</Antlr4ToolPath>
+    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolPath>
   </PropertyGroup>
 </Project>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'==''">$(MSBuildBinPath)</Antlr4BuildTaskLocation>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'!=''">$(Antlr4BuildTaskPath)</Antlr4BuildTaskLocation>
-    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-SNAPSHOT-complete.jar</Antlr4ToolLocation>
+    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolLocation>
     <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'!=''">$(Antlr4ToolPath)</Antlr4ToolLocation>
 
     <Antlr4JavaVendor Condition="'$(Antlr4JavaVendor)'==''">JavaSoft</Antlr4JavaVendor>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net35.targets
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'==''">$(MSBuildBinPath)</Antlr4BuildTaskLocation>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'!=''">$(Antlr4BuildTaskPath)</Antlr4BuildTaskLocation>
-    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolLocation>
+    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.5-SNAPSHOT-complete.jar</Antlr4ToolLocation>
     <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'!=''">$(Antlr4ToolPath)</Antlr4ToolLocation>
 
     <Antlr4JavaVendor Condition="'$(Antlr4JavaVendor)'==''">JavaSoft</Antlr4JavaVendor>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
@@ -5,6 +5,6 @@
     <Antlr4BuildTaskPath Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net40</Antlr4BuildTaskPath>
     <Antlr4BuildTaskPath Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard</Antlr4BuildTaskPath>
     <!-- Path to the ANTLR tool itself -->
-    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-SNAPSHOT-complete.jar</Antlr4ToolPath>
+    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolPath>
   </PropertyGroup>
 </Project>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
@@ -5,6 +5,6 @@
     <Antlr4BuildTaskPath Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net40</Antlr4BuildTaskPath>
     <Antlr4BuildTaskPath Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard</Antlr4BuildTaskPath>
     <!-- Path to the ANTLR tool itself -->
-    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolPath>
+    <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.5-SNAPSHOT-complete.jar</Antlr4ToolPath>
   </PropertyGroup>
 </Project>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
@@ -29,7 +29,7 @@
   <PropertyGroup>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'==''">$(MSBuildBinPath)</Antlr4BuildTaskLocation>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'!=''">$(Antlr4BuildTaskPath)</Antlr4BuildTaskLocation>
-    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-SNAPSHOT-complete.jar</Antlr4ToolLocation>
+    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolLocation>
     <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'!=''">$(Antlr4ToolPath)</Antlr4ToolLocation>
 
     <Antlr4JavaVendor Condition="'$(Antlr4JavaVendor)'==''">JavaSoft</Antlr4JavaVendor>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
@@ -29,7 +29,7 @@
   <PropertyGroup>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'==''">$(MSBuildBinPath)</Antlr4BuildTaskLocation>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'!=''">$(Antlr4BuildTaskPath)</Antlr4BuildTaskLocation>
-    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-complete.jar</Antlr4ToolLocation>
+    <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.5-SNAPSHOT-complete.jar</Antlr4ToolLocation>
     <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'!=''">$(Antlr4ToolPath)</Antlr4ToolLocation>
 
     <Antlr4JavaVendor Condition="'$(Antlr4JavaVendor)'==''">JavaSoft</Antlr4JavaVendor>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
@@ -22,6 +22,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <Antlr4DesignTimeBuild>false</Antlr4DesignTimeBuild>
+    <Antlr4DesignTimeBuild Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">true</Antlr4DesignTimeBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'==''">$(MSBuildBinPath)</Antlr4BuildTaskLocation>
     <Antlr4BuildTaskLocation Condition="'$(Antlr4BuildTaskPath)'!=''">$(Antlr4BuildTaskPath)</Antlr4BuildTaskLocation>
     <Antlr4ToolLocation Condition="'$(Antlr4ToolPath)'==''">$(MSBuildBinPath)\Antlr4\antlr4-csharp-4.6.4-SNAPSHOT-complete.jar</Antlr4ToolLocation>
@@ -88,7 +93,7 @@
 
   <Target Name="Antlr4DesignTimeGrammarCompilation">
     <!-- Only if we are not actually performing a compile i.e. we are in design mode -->
-    <CallTarget Condition="'$(BuildingProject)' != 'true'"
+    <CallTarget Condition="'$(Antlr4DesignTimeBuild)' == 'true'"
                 Targets="Antlr4Compile" />
   </Target>
 
@@ -103,10 +108,6 @@
       <Antlr4GeneratedCodeFiles Remove="@(Antlr4GeneratedCodeFiles)" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <_IntellisenseOnlyCompile>false</_IntellisenseOnlyCompile>
-      <_IntellisenseOnlyCompile Condition="'$(BuildingProject)' != 'true'">true</_IntellisenseOnlyCompile>
-    </PropertyGroup>
     <Antlr4ClassGenerationTask
       ToolPath="$(Antlr4ToolLocation)"
       JavaVendor="$(Antlr4JavaVendor)"
@@ -119,7 +120,7 @@
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetNamespace="%(Antlr4.CustomToolNamespace)"
       SourceCodeFiles="@(Antlr4 -> '%(FullPath)')"
-      ContinueOnError="$(_IntellisenseOnlyCompile)"
+      ContinueOnError="$(Antlr4DesignTimeBuild)"
       TokensFiles="@(Antlr4Tokens)"
       AbstractGrammarFiles="@(Antlr4AbstractGrammar)"
       LanguageSourceExtensions="$(DefaultLanguageSourceExtension)"
@@ -132,7 +133,7 @@
     </Antlr4ClassGenerationTask>
 
     <WriteLinesToFile
-      Condition="'$(_IntellisenseOnlyCompile)' != 'true'"
+      Condition="'$(Antlr4DesignTimeBuild)' != 'true'"
       File="$(IntermediateOutputPath)$(Antlr4GenCodeFileNames)"
       Lines="@(Antlr4GeneratedCodeFiles)"
       Overwrite="true"/>

--- a/runtime/CSharp/Antlr4BuildTasks/Properties/AssemblyInfo.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.6.0.0")]
-[assembly: AssemblyFileVersion("4.6.4.0")]
-[assembly: AssemblyInformationalVersion("4.6.4")]
+[assembly: AssemblyFileVersion("4.6.5.0")]
+[assembly: AssemblyInformationalVersion("4.6.5-dev")]

--- a/runtime/CSharp/Antlr4BuildTasks/Properties/AssemblyInfo.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Properties/AssemblyInfo.cs
@@ -38,4 +38,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.6.0.0")]
 [assembly: AssemblyFileVersion("4.6.4.0")]
-[assembly: AssemblyInformationalVersion("4.6.4-dev")]
+[assembly: AssemblyInformationalVersion("4.6.4")]

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tunnelvisionlabs</groupId>
     <artifactId>antlr4-csharp</artifactId>
-    <version>4.6.4</version>
+    <version>4.6.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ANTLR 4 Target C#</name>
@@ -68,7 +68,7 @@
         <url>https://github.com/tunnelvisionlabs/antlr4cs/tree/master</url>
         <connection>scm:git:git://github.com/tunnelvisionlabs/antlr4cs.git</connection>
         <developerConnection>scm:git:git@github.com:tunnelvisionlabs/antlr4cs.git</developerConnection>
-        <tag>v4.6.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tunnelvisionlabs</groupId>
     <artifactId>antlr4-csharp</artifactId>
-    <version>4.6.4-SNAPSHOT</version>
+    <version>4.6.4</version>
     <packaging>jar</packaging>
 
     <name>ANTLR 4 Target C#</name>
@@ -68,7 +68,7 @@
         <url>https://github.com/tunnelvisionlabs/antlr4cs/tree/master</url>
         <connection>scm:git:git://github.com/tunnelvisionlabs/antlr4cs.git</connection>
         <developerConnection>scm:git:git@github.com:tunnelvisionlabs/antlr4cs.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v4.6.4</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
Fixes the IntelliSense experience when working in projects using the new project system in Visual Studio 2017. See dotnet/project-system#2488 for a related issue.

Thanks to @srivatsn for the help identifying the problem and providing the MSBuild condition that works for both legacy and new project systems. 🏆 