### PR TITLE
Remove IKVM from the distribution

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 
 > :warning: Starting with release 4.5.0-alpha003, users are no longer required to install the Java Runtime in order to compile .NET applications using ANTLR 4. However, installing Java will dramatically improve the performance of the code generation process. It is highly recommended, especially on developer machines where background code generation is used for IntelliSense functionality.
 
-The C# target for ANTLR 4 requires Java (or IKVM) for *compiling* applications. The resulting compiled C# applications will not require Java (or IKVM) to be installed. You can install *any* of the following versions of Java to use this target.
+The C# target for ANTLR 4 uses Java for *compiling* applications. The resulting compiled C# applications will not require Java to be installed. You can install *any* of the following versions of Java to use this target.
 
 If you already have one of the following installed, you should check to make sure the installation is up-to-date.
 
@@ -19,7 +19,7 @@ If you already have one of the following installed, you should check to make sur
 * Java 6 runtime environment (x86 or x64)
 * Java 6 development kit (x86 or x64, provided that the JRE option is also installed during the development kit installation)
 
-If no suitable version of Java could be located on the machine, the build tools will automatically fall back to using IKVM instead.
+If no suitable version of Java could be located on the machine, the build tools will automatically fall back to using the new C# implementation of the code generation tool instead.
 
 ### Step 2: Install ANTLR Language Support for Visual Studio (optional)
 

--- a/build/Antlr4.CodeGenerator.nuspec
+++ b/build/Antlr4.CodeGenerator.nuspec
@@ -22,25 +22,6 @@
     <!-- Tools -->
 
     <file src="..\tool\target\antlr4-csharp-$CSharpToolVersion$-complete.jar" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe.config" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Core.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Text.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Charsets.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Naming.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Management.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Beans.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Corba.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Util.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Security.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.JNI.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.SwingAWT.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Remoting.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.XML.API.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Misc.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Media.dll" target="tools"/>
 
     <!-- New ANTLR 4 Tool (Written in C#) -->
     <file src="..\runtime\CSharp\Antlr4.Tool\bin\$Configuration$\net45\Antlr4.exe" target="tools\net45" />

--- a/build/Antlr4.VS2008.nuspec
+++ b/build/Antlr4.VS2008.nuspec
@@ -25,25 +25,6 @@
     <!-- Tools -->
 
     <file src="..\tool\target\antlr4-csharp-$CSharpToolVersion$-complete.jar" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\ikvm.exe.config" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Core.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Text.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Charsets.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Naming.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Management.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Beans.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Corba.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Util.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Security.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.JNI.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.Runtime.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.SwingAWT.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Remoting.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.XML.API.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Misc.dll" target="tools"/>
-    <file src="..\runtime\CSharp\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.OpenJDK.Media.dll" target="tools"/>
 
     <!-- New ANTLR 4 Tool (Written in C#) -->
     <file src="..\runtime\CSharp\Antlr4.Tool\bin\$Configuration$\net45\Antlr4.exe" target="tools\net45" />

--- a/runtime/CSharp/.nuget/packages.config
+++ b/runtime/CSharp/.nuget/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IKVM-WithExes" version="7.3.4830.1" targetFramework="net4" />
 </packages>

--- a/runtime/CSharp/Antlr4.sln
+++ b/runtime/CSharp/Antlr4.sln
@@ -39,6 +39,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4BuildTasks", "Antlr4B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4.Tool", "Antlr4.Tool\Antlr4.Tool.csproj", "{01A6A165-9DB4-4F46-9B1B-C31B918922EF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{52491CB2-3BEF-493F-808B-FE0CE62CACE6}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -67,6 +73,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4CE79A54-058D-4940-875E-7F6AA9922A7D} = {47C0086D-577C-43DA-ADC7-544F27656E45}
+		{52491CB2-3BEF-493F-808B-FE0CE62CACE6} = {47C0086D-577C-43DA-ADC7-544F27656E45}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {03D09E30-D6C7-4053-95DD-AD0D62B0ED78}

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -244,19 +244,8 @@ namespace Antlr4.Build.Tasks
         {
             try
             {
-                string executable;
-                if (UseCSharpGenerator)
-                {
-#if NETSTANDARD
-                    string framework = "netstandard";
-                    string extension = ".dll";
-#else
-                    string framework = "net45";
-                    string extension = ".exe";
-#endif
-                    executable = Path.Combine(Path.Combine(Path.GetDirectoryName(ToolPath), framework), "Antlr4" + extension);
-                }
-                else
+                string executable = null;
+                if (!UseCSharpGenerator)
                 {
                     try
                     {
@@ -274,9 +263,21 @@ namespace Antlr4.Build.Tasks
                     }
                     catch (NotSupportedException)
                     {
-                        // Fall back to using IKVM
-                        executable = Path.Combine(Path.GetDirectoryName(ToolPath), "ikvm.exe");
+                        // Fall back to using the new code generation tools
+                        UseCSharpGenerator = true;
                     }
+                }
+
+                if (UseCSharpGenerator)
+                {
+#if NETSTANDARD
+                    string framework = "netstandard";
+                    string extension = ".dll";
+#else
+                    string framework = "net45";
+                    string extension = ".exe";
+#endif
+                    executable = Path.Combine(Path.Combine(Path.GetDirectoryName(ToolPath), framework), "Antlr4" + extension);
                 }
 
                 List<string> arguments = new List<string>();


### PR DESCRIPTION
The build tools now use the C# port of the code generator when Java
could not be located.

Closes #130