### PR TITLE
Visual Studio 2017 is required to open the solution

### DIFF
--- a/runtime/CSharp/Antlr4.sln
+++ b/runtime/CSharp/Antlr4.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26711.1
-MinimumVisualStudioVersion = 10.0.40219.1
+MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{47C0086D-577C-43DA-ADC7-544F27656E45}"
 	ProjectSection(SolutionItems) = preProject
 		..\..\appveyor.yml = ..\..\appveyor.yml


### PR DESCRIPTION
This change improves the error message when users try to open the solution in earlier versions of Visual Studio.