### PR TITLE
Avoid console redirection

### DIFF
--- a/runtime/CSharp/Antlr4.Tool/Automata/ParserATNFactory.cs
+++ b/runtime/CSharp/Antlr4.Tool/Automata/ParserATNFactory.cs
@@ -121,7 +121,7 @@ namespace Antlr4.Automata
                     Rule(r.ast, r.name, h);
                 }
                 catch (RecognitionException re) {
-                    ErrorManager.FatalInternalError("bad grammar AST structure", re);
+                    g.tool.errMgr.FatalInternalError("bad grammar AST structure", re);
                 }
             }
         }

--- a/runtime/CSharp/Antlr4.Tool/Codegen/OutputModelController.cs
+++ b/runtime/CSharp/Antlr4.Tool/Codegen/OutputModelController.cs
@@ -14,7 +14,6 @@ namespace Antlr4.Codegen
     using Antlr4.Tool;
     using Antlr4.Tool.Ast;
     using CommonTreeNodeStream = Antlr.Runtime.Tree.CommonTreeNodeStream;
-    using Console = System.Console;
 
     /** This receives events from SourceGenTriggers.g and asks factory to do work.
      *  Then runs extensions in order on resulting SrcOps to get final list.
@@ -295,8 +294,8 @@ namespace Antlr4.Codegen
             }
             catch (Antlr.Runtime.RecognitionException e)
             {
-                Console.Error.WriteLine(e.Message);
-                Console.Error.WriteLine(e.StackTrace);
+                @delegate.GetGenerator().tool.ConsoleError.WriteLine(e.Message);
+                @delegate.GetGenerator().tool.ConsoleError.WriteLine(e.StackTrace);
             }
 
             function.ctxType = @delegate.GetTarget().GetRuleFunctionContextStructName(function);

--- a/runtime/CSharp/Antlr4.Tool/Tool/DefaultToolListener.cs
+++ b/runtime/CSharp/Antlr4.Tool/Tool/DefaultToolListener.cs
@@ -4,7 +4,6 @@
 namespace Antlr4.Tool
 {
     using Antlr4.StringTemplate;
-    using Console = System.Console;
 
     /** */
     public class DefaultToolListener : ANTLRToolListener
@@ -23,7 +22,7 @@ namespace Antlr4.Tool
                 msg = msg.Replace('\n', ' ');
             }
 
-            Console.WriteLine(msg);
+            tool.ConsoleOut.WriteLine(msg);
         }
 
         public virtual void Error(ANTLRMessage msg)
@@ -35,7 +34,7 @@ namespace Antlr4.Tool
                 outputMsg = outputMsg.Replace('\n', ' ');
             }
 
-            Console.Error.WriteLine(outputMsg);
+            tool.ConsoleError.WriteLine(outputMsg);
         }
 
         public virtual void Warning(ANTLRMessage msg)
@@ -47,7 +46,7 @@ namespace Antlr4.Tool
                 outputMsg = outputMsg.Replace('\n', ' ');
             }
 
-            Console.Error.WriteLine(outputMsg);
+            tool.ConsoleError.WriteLine(outputMsg);
         }
     }
 }

--- a/runtime/CSharp/Antlr4.Tool/Tool/ErrorManager.cs
+++ b/runtime/CSharp/Antlr4.Tool/Tool/ErrorManager.cs
@@ -9,7 +9,6 @@ namespace Antlr4.Tool
     using System.Reflection;
     using System.Text;
     using Antlr4.StringTemplate;
-    using Console = System.Console;
     using ErrorBuffer = Antlr4.StringTemplate.Misc.ErrorBuffer;
     using Exception = System.Exception;
     using File = System.IO.File;
@@ -137,24 +136,24 @@ namespace Antlr4.Tool
             Emit(etype, msg);
         }
 
-        public static void FatalInternalError(string error, Exception e)
+        public void FatalInternalError(string error, Exception e)
         {
             InternalError(error, e);
             throw new Exception(error, e);
         }
 
-        public static void InternalError(string error, Exception e)
+        public void InternalError(string error, Exception e)
         {
             string location = GetLastNonErrorManagerCodeLocation(e);
             InternalError("Exception " + e + "@" + location + ": " + error);
         }
 
-        public static void InternalError(string error)
+        public void InternalError(string error)
         {
             string location =
                 GetLastNonErrorManagerCodeLocation(new Exception());
             string msg = location + ": " + error;
-            Console.Error.WriteLine("internal error: " + msg);
+            tool.ConsoleError.WriteLine("internal error: " + msg);
         }
 
         /**
@@ -290,17 +289,17 @@ namespace Antlr4.Tool
             bool ok = true;
             if (!format.IsDefined("location"))
             {
-                Console.Error.WriteLine("Format template 'location' not found in " + formatName);
+                tool.ConsoleError.WriteLine("Format template 'location' not found in " + formatName);
                 ok = false;
             }
             if (!format.IsDefined("message"))
             {
-                Console.Error.WriteLine("Format template 'message' not found in " + formatName);
+                tool.ConsoleError.WriteLine("Format template 'message' not found in " + formatName);
                 ok = false;
             }
             if (!format.IsDefined("report"))
             {
-                Console.Error.WriteLine("Format template 'report' not found in " + formatName);
+                tool.ConsoleError.WriteLine("Format template 'report' not found in " + formatName);
                 ok = false;
             }
             return ok;
@@ -309,16 +308,16 @@ namespace Antlr4.Tool
         /** If there are errors during ErrorManager init, we have no choice
          *  but to go to System.err.
          */
-        internal static void RawError(string msg)
+        internal void RawError(string msg)
         {
-            Console.Error.WriteLine(msg);
+            tool.ConsoleError.WriteLine(msg);
         }
 
-        internal static void RawError(string msg, Exception e)
+        internal void RawError(string msg, Exception e)
         {
             RawError(msg);
-            Console.Error.WriteLine(e.Message);
-            Console.Error.WriteLine(e.StackTrace);
+            tool.ConsoleError.WriteLine(e.Message);
+            tool.ConsoleError.WriteLine(e.StackTrace);
         }
 
         public virtual void Panic(ErrorType errorType, params object[] args)
@@ -333,7 +332,7 @@ namespace Antlr4.Tool
             Panic(outputMsg);
         }
 
-        public static void Panic(string msg)
+        public void Panic(string msg)
         {
             RawError(msg);
             Panic();

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -332,21 +332,22 @@ namespace Antlr4.Build.Tasks
 #if NETSTANDARD
                 if (UseCSharpGenerator)
                 {
-                    var oldOut = Console.Out;
-                    var oldError = Console.Error;
                     var outWriter = new StringWriter();
                     var errorWriter = new StringWriter();
                     try
                     {
-                        Console.SetOut(outWriter);
-                        Console.SetError(errorWriter);
-                        return AntlrTool.Main(arguments.ToArray()) == 0;
+                        var antlr = new AntlrTool(arguments.ToArray())
+                        {
+                            ConsoleOut = outWriter,
+                            ConsoleError = errorWriter
+                        };
+
+                        antlr.ProcessGrammarsOnCommandLine();
+
+                        return antlr.errMgr.GetNumErrors() == 0;
                     }
                     finally
                     {
-                        Console.SetOut(oldOut);
-                        Console.SetError(oldError);
-
                         foreach (var line in outWriter.ToString().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
                         {
                             HandleOutputDataReceived(line);


### PR DESCRIPTION
During builds, redirect ANTLR tool output instead of the console streams.