### PR TITLE
performance optimization in DFA.IsEmpty and DFA.IsContextSensitive.

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime/Dfa/DFA.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Dfa/DFA.cs
@@ -248,7 +248,7 @@ namespace Antlr4.Runtime.Dfa
             {
                 if (IsPrecedenceDfa)
                 {
-                    return s0.Get().EdgeMap.Count == 0 && s0full.Get().EdgeMap.Count == 0;
+                    return s0.Get().IsEdgeMapEmpty && s0full.Get().IsEdgeMapEmpty;
                 }
                 return s0.Get() == null && s0full.Get() == null;
             }
@@ -260,7 +260,7 @@ namespace Antlr4.Runtime.Dfa
             {
                 if (IsPrecedenceDfa)
                 {
-                    return s0full.Get().EdgeMap.Count != 0;
+                    return !s0full.Get().IsEdgeMapEmpty;
                 }
                 return s0full.Get() != null;
             }

--- a/runtime/CSharp/Antlr4.Runtime/Dfa/DFAState.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Dfa/DFAState.cs
@@ -207,6 +207,14 @@ namespace Antlr4.Runtime.Dfa
             }
         }
 
+        public bool IsEdgeMapEmpty
+        {
+            get
+            {
+                return edges.IsEmpty;
+            }
+        }
+
         public virtual DFAState GetContextTarget(int invokingState)
         {
             lock (this)


### PR DESCRIPTION
 Both properties were calling DFAState.EdgeMap property which is returning a copy of the internal EdgeMap. Creating a copy is avoided by calling newly introduced DFAState.IsEdgeMapEmpty property.