### PR TITLE
Fix support for abstract grammars in the new project system

### DIFF
--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -51,4 +51,10 @@
     <PackageReference Include="Antlr4" Version="4.6.5-dev" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Antlr4 Update="Grammar.g4">
+      <Abstract>true</Abstract>
+    </Antlr4>
+  </ItemGroup>
+
 </Project>

--- a/build/DotnetValidation/Program.cs
+++ b/build/DotnetValidation/Program.cs
@@ -29,4 +29,20 @@ namespace DotnetValidation
             writeLine(subTree.ToStringTree(subParser));
         }
     }
+
+    class GrammarLexer : global::DotnetValidation.AbstractGrammarLexer
+    {
+        public GrammarLexer(ICharStream input)
+            : base(input)
+        {
+        }
+    }
+
+    class GrammarParser : global::DotnetValidation.AbstractGrammarParser
+    {
+        public GrammarParser(ITokenStream input)
+            : base(input)
+        {
+        }
+    }
 }

--- a/build/DotnetValidationJavaCodegen/DotnetValidation.csproj
+++ b/build/DotnetValidationJavaCodegen/DotnetValidation.csproj
@@ -50,4 +50,11 @@
   <ItemGroup>
     <PackageReference Include="Antlr4" Version="4.6.5-dev" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Antlr4 Update="Grammar.g4">
+      <Abstract>true</Abstract>
+    </Antlr4>
+  </ItemGroup>
+
 </Project>

--- a/build/DotnetValidationJavaCodegen/Program.cs
+++ b/build/DotnetValidationJavaCodegen/Program.cs
@@ -29,4 +29,20 @@ namespace DotnetValidation
             writeLine(subTree.ToStringTree(subParser));
         }
     }
+
+    class GrammarLexer : global::DotnetValidation.AbstractGrammarLexer
+    {
+        public GrammarLexer(ICharStream input)
+            : base(input)
+        {
+        }
+    }
+
+    class GrammarParser : global::DotnetValidation.AbstractGrammarParser
+    {
+        public GrammarParser(ITokenStream input)
+            : base(input)
+        {
+        }
+    }
 }

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.props
@@ -11,4 +11,24 @@
     <!-- Path to the ANTLR tool itself -->
     <Antlr4ToolPath>..\tools\antlr4-csharp-4.6.5-SNAPSHOT-complete.jar</Antlr4ToolPath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Antlr4IsSdkProject)' == ''">
+    <Antlr4IsSdkProject>False</Antlr4IsSdkProject>
+    <Antlr4IsSdkProject Condition="'$(TargetFramework)' != '' OR '$(TargetFrameworks)' != ''">True</Antlr4IsSdkProject>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(Antlr4IsSdkProject)' == 'True'">
+      <PropertyGroup>
+        <EnableDefaultAntlrItems Condition="'$(EnableDefaultAntlrItems)' == ''">True</EnableDefaultAntlrItems>
+      </PropertyGroup>
+
+      <ItemGroup Condition="'$(EnableDefaultItems)' == 'True'">
+        <Antlr4 Include="**/*.g4" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultAntlrItems)' == 'True'" />
+      </ItemGroup>
+      <ItemGroup Condition="'$(EnableDefaultItems)' == 'True' AND '$(EnableDefaultNoneItems)' == 'True'">
+        <None Remove="**/*.g4" Condition="'$(EnableDefaultAntlrItems)' == 'True'" />
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets
@@ -7,11 +7,6 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Antlr4IsSdkProject)' == ''">
-    <Antlr4IsSdkProject>False</Antlr4IsSdkProject>
-    <Antlr4IsSdkProject Condition="'$(TargetFramework)' != '' OR '$(TargetFrameworks)' != ''">True</Antlr4IsSdkProject>
-  </PropertyGroup>
-
   <PropertyGroup>
     <BuildSystem>MSBuild</BuildSystem>
     <TaskVersion>4.0.0.0</TaskVersion>
@@ -184,17 +179,6 @@
 
   <Choose>
     <When Condition="'$(Antlr4IsSdkProject)' == 'True'">
-      <PropertyGroup>
-        <EnableDefaultAntlrItems Condition="'$(EnableDefaultAntlrItems)' == ''">True</EnableDefaultAntlrItems>
-      </PropertyGroup>
-
-      <ItemGroup Condition="'$(EnableDefaultItems)' == 'True'">
-        <Antlr4 Include="**/*.g4" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultAntlrItems)' == 'True'" />
-      </ItemGroup>
-      <ItemGroup Condition="'$(EnableDefaultItems)' == 'True' AND '$(EnableDefaultNoneItems)' == 'True'">
-        <None Remove="**/*.g4" Condition="'$(EnableDefaultAntlrItems)' == 'True'" />
-      </ItemGroup>
-
       <ItemGroup>
         <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\Antlr4.ProjectItemsSchema.xml">
           <Context>Project</Context>


### PR DESCRIPTION
This change moves the default item handling for grammar files from the .targets
file to the .props file, restoring the ability to update properties within the
main project file.

Fixes #279