### PR TITLE
Add support for NCrunch

### DIFF
--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.CodeGenerator.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.CodeGenerator.targets
@@ -196,4 +196,16 @@
   </Choose>
 
   <Import Condition="'$(Antlr4IsSdkProject)' == 'True'" Project="Antlr4.CodeGenerator.DefaultItems.targets" />
+  
+  <!-- Support for NCrunch -->
+  <ItemGroup Condition="'$(NCrunch)' == '1'">
+    <!-- NCrunch tries to copy the fewest possible files to its build directory, those it misses are declared here. -->
+    <!-- The tools directory needs to be copied in projects that use packages.config. -->
+    <None Include="$(MSBuildThisFileDirectory)..\tools\**\*" Condition="'$(Antlr4IsSdkProject)' != 'True'" />
+    <!-- NCrunch only copies files from known item types, so we need to add ANTLR-specific items. -->
+    <None Include="@(Antlr4)" />
+    <None Include="@(Antlr4Tokens)" />
+    <None Include="@(Antlr4AbstractGrammar)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
[NCrunch](https://www.ncrunch.net/) is a test runner on steroids which uses its own build directory and unfortunately requires additional configuration for each project that uses custom build tasks.

This PR makes the ANTLR code generator work out of the box by declaring additional items when the project is built under NCrunch. These items are automatically copied to NCrunch's build directory ([docs here](https://www.ncrunch.net/documentation/considerations-and-constraints_implicit-file-dependencies)).

I hope you won't mind adding this, as it will make life easier for those that use ANTLR along with NCrunch.
