### PR TITLE
Improve command line argument quoting logic

### DIFF
--- a/runtime/CSharp/Antlr4.sln
+++ b/runtime/CSharp/Antlr4.sln
@@ -44,6 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{52491C
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4BuildTasks.Test", "Antlr4BuildTasks.Test\Antlr4BuildTasks.Test.csproj", "{A567F674-1998-4919-BDEF-BCD0C987A83D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,10 @@ Global
 		{01A6A165-9DB4-4F46-9B1B-C31B918922EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01A6A165-9DB4-4F46-9B1B-C31B918922EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01A6A165-9DB4-4F46-9B1B-C31B918922EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A567F674-1998-4919-BDEF-BCD0C987A83D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A567F674-1998-4919-BDEF-BCD0C987A83D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A567F674-1998-4919-BDEF-BCD0C987A83D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A567F674-1998-4919-BDEF-BCD0C987A83D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/runtime/CSharp/Antlr4BuildTasks.Test/Antlr4BuildTasks.Test.csproj
+++ b/runtime/CSharp/Antlr4BuildTasks.Test/Antlr4BuildTasks.Test.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net40</TargetFrameworks>
+    <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
+
+    <Description>Unit tests for ANTLR 4 build tasks.</Description>
+    <Copyright>Copyright © Sam Harwell 2013</Copyright>
+    <Company>Tunnel Vision Laboratories, LLC</Company>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'net40'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);NET40;NET40PLUS;NET35PLUS;NET30PLUS;NET20PLUS</DefineConstants>
+        <MSTest2>False</MSTest2>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <ProjectReference Include="..\Antlr4BuildTasks\Antlr4BuildTasks.csproj">
+          <SetTargetFramework>TargetFramework=net40</SetTargetFramework>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\build\keys\TestingKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(MSTest2)' == 'false'">
+      <!-- Workaround for https://github.com/dotnet/roslyn-project-system/issues/1739 -->
+      <PropertyGroup>
+        <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+        <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup>
+    <None Include="..\..\..\build\keys\TestingKey.snk">
+      <Link>TestingKey.snk</Link>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/runtime/CSharp/Antlr4BuildTasks.Test/Properties/AssemblyInfo.cs
+++ b/runtime/CSharp/Antlr4BuildTasks.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Terence Parr, Sam Harwell. All Rights Reserved.
+// Licensed under the BSD License. See LICENSE.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4AA8C780-9E51-4F31-AC04-A80D144A7D48")]

--- a/runtime/CSharp/Antlr4BuildTasks.Test/TestCommandLineHelper.cs
+++ b/runtime/CSharp/Antlr4BuildTasks.Test/TestCommandLineHelper.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Terence Parr, Sam Harwell. All Rights Reserved.
+// Licensed under the BSD License. See LICENSE.txt in the project root for license information.
+
+namespace Antlr4BuildTasks.Test
+{
+    using Antlr4.Build.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Defines test cases for <see cref="CommandLineHelper"/>
+    /// </summary>
+    [TestClass]
+    public class TestCommandLineHelper
+    {
+        [TestMethod]
+        [Description("Verifies that there are no unnecessary double quotes added.")]
+        public void JoinArgumentsDoesNotAddUnnecessaryQuotes()
+        {
+            Assert.AreEqual(
+                @"-o C:\somedir\ grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\somedir\", "grammar.g4"}));
+        }
+
+        [TestMethod]
+        [Description("Verifies that arguments with spaces in them are being enclosed in double quotes.")]
+        public void JoinArgumentsQuotesArgsWithSpaces()
+        {
+            Assert.AreEqual(
+                @"-o ""C:\some dir"" grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\some dir", "grammar.g4" }));
+        }
+
+        [TestMethod]
+        [Description("Verifies that arguments with double quotes in them are being enclosed in double quotes and double quotes within the argument are properly escaped.")]
+        public void JoinArgumentsAddsQuotesToArgsWithQuotes()
+        {
+            Assert.AreEqual(
+                @"-o ""C:\some\""dir"" grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\some""dir", "grammar.g4" }));
+        }
+
+        [TestMethod]
+        [Description("Verifies that arguments with backslash followed by double quote are being enclosed in double quotes and all special characters within the argument are properly escaped.")]
+        public void JoinArgumentsEscapesBackSlashBeforeDoubleQuote()
+        {
+            Assert.AreEqual(
+                @"-o ""C:\some\\\""dir"" grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\some\""dir", "grammar.g4" }));
+        }
+
+        [TestMethod]
+        [Description("Verifies that arguments with multiple backslashes followed by double quote are being enclosed in double quotes and all special characters within the argument are properly escaped.")]
+        public void JoinArgumentsEscapesMultipleBackSlashesBeforeDoubleQuote()
+        {
+            Assert.AreEqual(
+                @"-o ""C:\some\\\\\""dir"" grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\some\\""dir", "grammar.g4" }));
+        }
+
+        [TestMethod]
+        [Description("Verifies that arguments with spaces and trailing backslash are being enclosed in double quotes and backslash within the argument is properly escaped.")]
+        public void JoinArgumentsEscapesTrailingBackSlashesInQuotedArgs()
+        {
+            Assert.AreEqual(
+                @"-o ""C:\some dir\\"" grammar.g4",
+                CommandLineHelper.JoinArguments(new[] { "-o", @"C:\some dir\", "grammar.g4" }));
+        }
+    }
+}

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -316,7 +316,7 @@ namespace Antlr4.Build.Tasks
                 }
 #endif
 
-                ProcessStartInfo startInfo = new ProcessStartInfo(executable, JoinArguments(arguments))
+                ProcessStartInfo startInfo = new ProcessStartInfo(executable, CommandLineHelper.JoinArguments(arguments))
                 {
                     UseShellExecute = false,
                     CreateNoWindow = true,
@@ -358,35 +358,6 @@ namespace Antlr4.Build.Tasks
                 _buildMessages.Add(new BuildMessage(e.Message));
                 throw;
             }
-        }
-
-        private static string JoinArguments(IEnumerable<string> arguments)
-        {
-            if (arguments == null)
-                throw new ArgumentNullException("arguments");
-
-            StringBuilder builder = new StringBuilder();
-            foreach (string argument in arguments)
-            {
-                if (builder.Length > 0)
-                    builder.Append(' ');
-
-                if (argument.IndexOfAny(new[] { '"', ' ' }) < 0)
-                {
-                    builder.Append(argument);
-                    continue;
-                }
-
-                // escape a backslash appearing before a quote
-                string arg = argument.Replace("\\\"", "\\\\\"");
-                // escape double quotes
-                arg = arg.Replace("\"", "\\\"");
-
-                // wrap the argument in outer quotes
-                builder.Append('"').Append(arg).Append('"');
-            }
-
-            return builder.ToString();
         }
 
         private static readonly Regex GeneratedFileMessageFormat = new Regex(@"^Generating file '(?<OUTPUT>.*?)' for grammar '(?<GRAMMAR>.*?)'$", RegexOptions.Compiled);

--- a/runtime/CSharp/Antlr4BuildTasks/CommandLineHelper.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/CommandLineHelper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Terence Parr, Sam Harwell. All Rights Reserved.
+// Licensed under the BSD License. See LICENSE.txt in the project root for license information.
+
+namespace Antlr4.Build.Tasks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Defines helper methods to work with command line and arguments.
+    /// </summary>
+    public static class CommandLineHelper
+    {
+        /// <summary>
+        /// Joins multiple command line arguments together into one string using space as a separator,
+        /// applying all necessary quoting and escaping.
+        /// </summary>
+        /// <param name="arguments">Command line argument to join</param>
+        /// <returns>String that contains all command line arguments joined together.</returns>
+        public static string JoinArguments(IEnumerable<string> arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException("arguments");
+
+            StringBuilder builder = new StringBuilder();
+            foreach (string argument in arguments)
+            {
+                if (builder.Length > 0)
+                    builder.Append(' ');
+
+                if (argument.IndexOfAny(new[] { '"', ' ' }) < 0)
+                {
+                    builder.Append(argument);
+                    continue;
+                }
+
+                // escape backslashes appearing before a double quote or end of line by doubling them
+                string arg = Regex.Replace(argument, @"(\\+)(""|$)", "$1$1$2");
+                // escape double quotes
+                arg = arg.Replace("\"", "\\\"");
+
+                // wrap the argument in outer quotes
+                builder.Append('"').Append(arg).Append('"');
+            }
+
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
We hit an issue where C# generator tool would exit with no error message and no files generated.

After troubleshooting I root-caused the issue to .NET command line parsing rules, where special characters like double-quotes and backslashes have to be escaped under some circumstances.

There already was a code to handle some of these cases, but it didn't cover the following:
1) When there are multiple backslashes preceding the double-quote, we need to escape all of them, not only the last one.
2) When there is a backslash at the end of the argument, we need to escape it, otherwise it will escape the double-quote appended by the code itself, causing attribute value to run out when parsed by .NET infrastructure.

This change is improving the logic to account for these two extra cases. I also added unit tests to demonstrate the behavior. In order to do so, I had to move the JoinArguments method to a public helper class, so that it can be accessed from unit tests, as I'm not a big fan of InternalsVisibleTo.