### PR TITLE
Implement DebuggerNonUserCode as an option in response to issue #106

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -149,7 +149,7 @@ The following table describes the properties available for customizing the code 
 | `ForceAtn` | Force ATN | `True` or `False` | When `True`, the generated parser will use `AdaptivePredict` for all decisions, including LL(1) decisions. |
 | `Listener` | Generate Listener | `True` or `False` | When `True`, a parse tree listener interface and base class will be generated for the parLitser. |
 | `Visitor` | Generate Visitor | `True` or `False` | When `True`, a parse tree visitor interface and base class will be generated for the parser. |
-
+| `IncludeDebuggerNonUserCodeAttribute` | `Include DebuggerNonUserCode attribute` | `True` or `False` | When `True`, each method will have the DebuggerNonUserCode attribute attribute added. |
 #### Using the ANTLR Language Support extension
 
 1. Right click the grammar file in **Solution Explorer** and select **Properties**

--- a/runtime/CSharp/Antlr4.Tool/Codegen/Model/OutputFile.cs
+++ b/runtime/CSharp/Antlr4.Tool/Codegen/Model/OutputFile.cs
@@ -14,6 +14,7 @@ namespace Antlr4.Codegen.Model
         public readonly string ANTLRVersion;
         public readonly string TokenLabelType;
         public readonly string InputSymbolType;
+        public readonly bool IncludeDebuggerNonUserCodeAttribute; // from -DincludeDebuggerNonUserCodeAttribute
 
         protected OutputFile(OutputModelFactory factory, string fileName)
             : base(factory)
@@ -24,6 +25,7 @@ namespace Antlr4.Codegen.Model
             ANTLRVersion = AntlrTool.VERSION;
             TokenLabelType = g.GetOptionString("TokenLabelType");
             InputSymbolType = TokenLabelType;
+            IncludeDebuggerNonUserCodeAttribute = System.StringComparer.OrdinalIgnoreCase.Equals( g.GetOptionString("includeDebuggerNonUserCodeAttribute"), "true" );
         }
 
         public virtual IDictionary<string, Action> BuildNamedActions(Grammar g)

--- a/runtime/CSharp/Antlr4.Tool/Tool/Grammar.cs
+++ b/runtime/CSharp/Antlr4.Tool/Tool/Grammar.cs
@@ -67,6 +67,7 @@ namespace Antlr4.Tool
                 "tokenVocab",
                 "language",
                 "exportMacro",
+                "includeDebuggerNonUserCodeAttribute",
                 };
 
         public static readonly ISet<string> lexerOptions = parserOptions;

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.CodeGenerator.targets
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.CodeGenerator.targets
@@ -85,6 +85,7 @@
       <Visitor>true</Visitor>
       <Abstract>false</Abstract>
       <ForceAtn>false</ForceAtn>
+      <IncludeDebuggerNonUserCodeAttribute>false</IncludeDebuggerNonUserCodeAttribute>
     </Antlr4>
   </ItemDefinitionGroup>
 
@@ -149,7 +150,8 @@
       GenerateVisitor="%(Antlr4.Visitor)"
       ForceAtn="%(Antlr4.ForceAtn)"
       AbstractGrammar="%(Antlr4.Abstract)"
-      UseCSharpGenerator="$(Antlr4UseCSharpGenerator)">
+      UseCSharpGenerator="$(Antlr4UseCSharpGenerator)"
+      IncludeDebuggerNonUserCodeAttribute="$(IncludeDebuggerNonUserCodeAttribute)">
 
       <Output ItemName="Antlr4GeneratedCodeFiles" TaskParameter="GeneratedCodeFiles" />
     </Antlr4ClassGenerationTask>

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4.xml
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4.xml
@@ -40,7 +40,12 @@
     DisplayName="Abstract Grammar"
     Default="false"
     Description="When true, the generated classes are marked as abstract." />
-
+  <BoolProperty
+    Category="ANTLR"
+    Name="IncludeDebuggerNonUserCodeAttribute"
+    DisplayName="Include DebuggerNonUserCode attribute"
+    Default="false"
+    Description="When true, includes the DebuggerNonUserCode attribute against each method." />
   <!--
     The rest of these properties are not ANTLR-specific, but CPS provides no way to inherit properties, so if we fail to
     include them then they will just disappear.

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTask.cs
@@ -151,6 +151,12 @@ namespace Antlr4.Build.Tasks
             set;
         }
 
+        public bool IncludeDebuggerNonUserCodeAttribute
+        {
+            get;
+            set;
+        }
+
         [Output]
         public ITaskItem[] GeneratedCodeFiles
         {
@@ -306,6 +312,7 @@ namespace Antlr4.Build.Tasks
             wrapper.JavaInstallation = JavaInstallation;
             wrapper.JavaExecutable = JavaExecutable;
             wrapper.UseCSharpGenerator = UseCSharpGenerator;
+            wrapper.IncludeDebuggerNonUserCodeAttribute = IncludeDebuggerNonUserCodeAttribute;
             return wrapper;
         }
 

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -121,6 +121,12 @@ namespace Antlr4.Build.Tasks
             set;
         }
 
+        public bool IncludeDebuggerNonUserCodeAttribute
+        {
+            get;
+            set;
+        }
+
         public IList<string> SourceCodeFiles
         {
             get
@@ -283,6 +289,12 @@ namespace Antlr4.Build.Tasks
                 }
 
                 arguments.AddRange(SourceCodeFiles);
+
+                if (UseCSharpGenerator)
+                {
+                    if (IncludeDebuggerNonUserCodeAttribute)
+                        arguments.Add("-includeDebuggerNonUserCodeAttribute");
+                }
 
 #if NETSTANDARD
                 if (UseCSharpGenerator)

--- a/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
+++ b/runtime/CSharp/Antlr4BuildTasks/Antlr4ClassGenerationTaskInternal.cs
@@ -293,7 +293,7 @@ namespace Antlr4.Build.Tasks
                 if (UseCSharpGenerator)
                 {
                     if (IncludeDebuggerNonUserCodeAttribute)
-                        arguments.Add("-includeDebuggerNonUserCodeAttribute");
+                        arguments.Add("-DincludeDebuggerNonUserCodeAttribute");
                 }
 
 #if NETSTANDARD

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -86,6 +86,7 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 /// \</summary>
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public partial class <file.grammarName>BaseListener : I<file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /// \<summary>
@@ -184,6 +185,7 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 /// \<typeparam name="Result">The return type of the visit operation.\</typeparam>
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeVisitor\<Result>, I<file.grammarName>Visitor\<Result> {
 	<file.visitorNames:{lname |
 /// \<summary>
@@ -238,6 +240,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public <if(parser.abstractRecognizer)>abstract <endif>partial class <csIdentifier.(parser.name)> : <superClass; null="Parser"> {
 	<if(parser.tokens)>
 	public const int
@@ -843,6 +846,7 @@ CaptureNextToken(d) ::= "<d.varName> = _input.Lt(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = _input.La(1);"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public partial class <struct.name> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
@@ -866,6 +870,7 @@ public partial class <struct.name> : <if(contextSuperClass)><contextSuperClass><
 >>
 
 AltLabelStructDecl(struct,attrs,getters,dispatchMethods) ::= <<
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public partial class <struct.name> : <currentRule.name; format="cap">Context {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
@@ -961,6 +966,7 @@ using DFA = Antlr4.Runtime.Dfa.DFA;
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
+<if(file.IncludeDebuggerNonUserCodeAttribute)>[System.Diagnostics.DebuggerNonUserCode]<endif>
 public <if(lexer.abstractRecognizer)>abstract <endif>partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 	public const int
 		<lexer.tokens:{k | <tokenType.(k)>=<lexer.tokens.(k)>}; separator=", ", wrap, anchor>;


### PR DESCRIPTION
Introduce new property that can be used in the OutputFile derived classes to dictate whether to include the DebuggerNonUserCode attribute in generated code.

Added this to the build task and associated classes and to the documentation.

I've not implemented it in the same way as abstract was implemented it as it would have meant introducing multiple properties (in Lexer and Parser) to do the same thing. Obviously happy to change this if that is the preferred option.

Closes #106 