### PR TITLE
Add netstandard2.0 target

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ test_script:
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\%CONFIGURATION%\net35\Antlr4.Runtime.Test.dll"
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\%CONFIGURATION%\net30\Antlr4.Runtime.Test.dll"
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\%CONFIGURATION%\net20\Antlr4.Runtime.Test.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=runtime-suite" "C:\projects\antlr4cs\runtime\CSharp\Antlr4.Runtime.Test\bin\%CONFIGURATION%\netcoreapp2.1\Antlr4.Runtime.Test.dll"
 cache:
 - C:\MavenRepo -> **\pom.xml
 artifacts:

--- a/build/Antlr4.Runtime.nuspec
+++ b/build/Antlr4.Runtime.nuspec
@@ -27,6 +27,7 @@
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.0"/>
       </group>
+      <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
   <files>
@@ -63,6 +64,10 @@
     <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard1.1\Antlr4.Runtime.dll" target="lib\netstandard1.1"/>
     <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard1.1\Antlr4.Runtime.pdb" target="lib\netstandard1.1"/>
     <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard1.1\Antlr4.Runtime.xml" target="lib\netstandard1.1"/>
+
+    <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard2.0\Antlr4.Runtime.dll" target="lib\netstandard2.0"/>
+    <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard2.0\Antlr4.Runtime.pdb" target="lib\netstandard2.0"/>
+    <file src="..\runtime\CSharp\Antlr4.Runtime\bin\$Configuration$\netstandard2.0\Antlr4.Runtime.xml" target="lib\netstandard2.0"/>
 
     <!-- Source Code -->
 

--- a/build/DotnetValidation/DotnetValidation.csproj
+++ b/build/DotnetValidation/DotnetValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net20;net30;net35;net35-cf;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
+    <TargetFrameworks>net20;net30;net35;net35-cf;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <Antlr4UseCSharpGenerator>True</Antlr4UseCSharpGenerator>
   </PropertyGroup>

--- a/build/DotnetValidationJavaCodegen/DotnetValidation.csproj
+++ b/build/DotnetValidationJavaCodegen/DotnetValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net20;net30;net35;net35-cf;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
+    <TargetFrameworks>net20;net30;net35;net35-cf;net40;net45;netcoreapp1.1;portable40-net40+sl5+win8+wp8+wpa81;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <Antlr4UseCSharpGenerator>False</Antlr4UseCSharpGenerator>
   </PropertyGroup>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -188,6 +188,13 @@ If (-not $NoValidate) {
 	}
 
 	git 'clean' '-dxf' 'DotnetValidationJavaCodegen'
+	dotnet 'run' '--project' '.\DotnetValidationJavaCodegen\DotnetValidation.csproj' '--framework' 'netcoreapp2.1'
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	git 'clean' '-dxf' 'DotnetValidationJavaCodegen'
 	&$nuget 'restore' 'DotnetValidationJavaCodegen'
 	&$msbuild '/nologo' '/m' '/nr:false' '/t:Rebuild' $LoggerArgument "/verbosity:$Verbosity" "/p:Configuration=$BuildConfig" '.\DotnetValidationJavaCodegen\DotnetValidation.sln'
 	if (-not $?) {
@@ -236,6 +243,13 @@ If (-not $NoValidate) {
 If (-not $NoValidate) {
 	git 'clean' '-dxf' 'DotnetValidation'
 	dotnet 'run' '--project' '.\DotnetValidation\DotnetValidation.csproj' '--framework' 'netcoreapp1.1'
+	if (-not $?) {
+		$host.ui.WriteErrorLine('Build failed, aborting!')
+		Exit $LASTEXITCODE
+	}
+
+	git 'clean' '-dxf' 'DotnetValidation'
+	dotnet 'run' '--project' '.\DotnetValidation\DotnetValidation.csproj' '--framework' 'netcoreapp2.1'
 	if (-not $?) {
 		$host.ui.WriteErrorLine('Build failed, aborting!')
 		Exit $LASTEXITCODE

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -110,7 +110,7 @@ If (-not (Test-Path $nuget)) {
 		mkdir '..\runtime\CSharp\.nuget'
 	}
 
-	$nugetSource = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
+	$nugetSource = 'https://dist.nuget.org/win-x86-commandline/v5.7.0/nuget.exe'
 	Invoke-WebRequest $nugetSource -OutFile $nuget
 	If (-not $?) {
 		$host.ui.WriteErrorLine('Unable to download NuGet executable, aborting!')
@@ -131,6 +131,11 @@ If ($Logger) {
 }
 
 &$nuget 'restore' $SolutionPath -Project2ProjectTimeOut 1200
+if (-not $?) {
+	$host.ui.WriteErrorLine('Restore failed, aborting!')
+	Exit 1
+}
+
 &$msbuild '/nologo' '/m' '/nr:false' "/t:$Target" $LoggerArgument "/verbosity:$Verbosity" "/p:Configuration=$BuildConfig" "/p:VisualStudioVersion=$VisualStudioVersion" "/p:KeyConfiguration=$KeyConfiguration" $SolutionPath
 if (-not $?) {
 	$host.ui.WriteErrorLine('Build failed, aborting!')

--- a/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.csproj
+++ b/runtime/CSharp/Antlr4.Runtime.Test/Antlr4.Runtime.Test.csproj
@@ -2,8 +2,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Note: net452 is used for testing the netstandard1.1 target. -->
-    <TargetFrameworks>net20;net30;net35;portable40-net40+sl5+win8+wp8+wpa81;net40;net45;net452</TargetFrameworks>
+    <!-- Note:
+          - net452 is used for testing the netstandard1.1 target
+          - netcoreapp2.1 is used for testing the netstandard2.0 target
+     -->
+    <TargetFrameworks>net20;net30;net35;portable40-net40+sl5+win8+wp8+wpa81;net40;net45;net452;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
@@ -107,6 +110,18 @@
         <ProjectReference Include="..\Antlr4.Runtime\Antlr4.Runtime.csproj">
           <SetTargetFramework>TargetFramework=netstandard1.1</SetTargetFramework>
         </ProjectReference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);PORTABLE;NET45;NET45PLUS;NET40PLUS;NET35PLUS;NET30PLUS;NET20PLUS</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\Antlr4.Runtime\Antlr4.Runtime.csproj">
+          <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+        </ProjectReference>
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
       </ItemGroup>
     </When>
   </Choose>

--- a/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.csproj
+++ b/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net20;net30;net35-cf;net35-client;portable40-net40+sl5+win8+wp8+wpa81;net40-client;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net20;net30;net35-cf;net35-client;portable40-net40+sl5+win8+wp8+wpa81;net40-client;net45</TargetFrameworks>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
 
     <AssemblyVersion>4.6.0.0</AssemblyVersion>

--- a/runtime/CSharp/Antlr4.Runtime/ParserInterpreter.cs
+++ b/runtime/CSharp/Antlr4.Runtime/ParserInterpreter.cs
@@ -379,7 +379,6 @@ namespace Antlr4.Runtime
         /// </remarks>
         protected internal virtual int VisitDecisionState(DecisionState p)
         {
-            int edge = 1;
             int predictedAlt;
             ErrorHandler.Sync(this);
             int decision = p.decision;

--- a/runtime/CSharp/Antlr4.Runtime/Sharpen/Compat/SerializableAttribute.cs
+++ b/runtime/CSharp/Antlr4.Runtime/Sharpen/Compat/SerializableAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if PORTABLE || NETSTANDARD
+﻿#if (PORTABLE && !NETSTANDARD) || NETSTANDARD1_1
 
 namespace System
 {


### PR DESCRIPTION
This adds the `netstandard2.0` target to Antlr4.Runtime in order to avoid dependency version conflicts caused by .NET Standard 1.1 when referencing this package from recent versions of .NET Core. `netstandard2.0` is a recommended target for libraries that also target .NET Standard 1.x.

This adds a `netcoreapp2.1` test target in order to test `netstandard2.0`. I initially tried to update the AppVeyor build script to VS 2019, but too many things got in the way. Even staying on VS 2017, I had to make the script use NuGet v5.7.0 since v5.8.0 fails with a _"Duplicate frameworks found"_ error - I added this change as a separate commit.
